### PR TITLE
Replace print statements with logging and a real progressbar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+blessings
+progressbar2

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     url='http://code.google.com/p/shedskin/',
     scripts=['scripts/shedskin'],
     cmdclass={'test': run_tests},
+    install_requires=['blessings', 'progressbar2'],
     packages=['shedskin'],
     package_data={
         'shedskin': [

--- a/shedskin/config.py
+++ b/shedskin/config.py
@@ -59,7 +59,6 @@ class GlobalInfo:  # XXX add comments, split up
         self.msvc = False
         self.gcwarns = True
         self.pypy = False
-        self.silent = False
         self.backtrace = False
         self.makefile_name = 'Makefile'  # XXX other default?
         self.item_rvalue = {}
@@ -68,9 +67,10 @@ class GlobalInfo:  # XXX add comments, split up
         self.tempcount = {}
         self.fast_hash = False
         self.struct_unpack = {}
-        self.debug_level = 0
         self.maxhits = 0  # XXX amaze.py termination
         self.gc_cleanup = False
+        self.terminal = None
+        self.progressbar = None
 
     def init_directories(self):
         shedskin_directory = os.sep.join(__file__.split(os.sep)[:-1])

--- a/shedskin/error.py
+++ b/shedskin/error.py
@@ -3,6 +3,7 @@
 Copyright 2005-2013 Mark Dufour; License GNU GPL version 3 (See LICENSE)
 
 '''
+import logging
 import sys
 
 import infer
@@ -13,9 +14,9 @@ ERRORS = set()
 
 def error(msg, gx, node=None, warning=False, mv=None):
     if warning:
-        kind = '*WARNING*'
+        kind = logging.WARNING
     else:
-        kind = '*ERROR*'
+        kind = logging.ERROR
     if not mv and node and (node, 0, 0) in gx.cnode:
         mv = infer.inode(gx, node).mv
     filename = lineno = None
@@ -27,20 +28,21 @@ def error(msg, gx, node=None, warning=False, mv=None):
     if result not in ERRORS:
         ERRORS.add(result)
     if not warning:
-        print format_error(result)
+        print_error(result)
         sys.exit(1)
 
 
-def format_error(error):
+def print_error(error):
     (kind, filename, lineno, msg) = error
-    result = kind
+    result = ''
     if filename:
-        result += ' %s:' % filename
+        result += filename + ':'
         if lineno is not None:
-            result += '%d:' % lineno
-    return result + ' ' + msg
+            result += str(lineno) + ':'
+        result += ' '
+    logging.log(kind, result + msg)
 
 
 def print_errors():
     for error in sorted(ERRORS):
-        print format_error(error)
+        print_error(error)

--- a/shedskin/infer.py
+++ b/shedskin/infer.py
@@ -38,8 +38,6 @@ import random
 import sys
 from compiler.ast import Const, Node, AssAttr, Keyword, CallFunc, Getattr, Dict, List, Tuple, ListComp, Not, Compare, Name
 
-import progressbar
-
 import error
 import graph
 from python import StaticClass, lookup_class_module, Function, \
@@ -1064,6 +1062,7 @@ def update_progressbar(gx, perc):
     if not logger.isEnabledFor(logging.INFO):
         return
     if gx.progressbar is None:
+        import progressbar
         widgets = progressbar.widgets
         gx.progressbar = progressbar.ProgressBar(
             widgets=[widgets.Bar(marker='*'), widgets.Percentage()],

--- a/shedskin/infer.py
+++ b/shedskin/infer.py
@@ -1061,6 +1061,8 @@ def ifa_split_class(cl, dcpa, things, split):
 
 
 def update_progressbar(gx, perc):
+    if not logger.isEnabledFor(logging.INFO):
+        return
     if gx.progressbar is None:
         widgets = progressbar.widgets
         gx.progressbar = progressbar.ProgressBar(
@@ -1072,8 +1074,8 @@ def update_progressbar(gx, perc):
     with gx.terminal.location(x=0):
         gx.progressbar.update(perc)
     if perc == 1:
-        sys.stdout.write(gx.terminal.move_down)
-        # logger.info('%s%d%%', '*' * int(perc * 32), 100 * perc)
+        # Finished, so add a new line.
+        sys.stdout.write('\n')
 
 # --- cartesian product algorithm (cpa) & iterative flow analysis (ifa)
 

--- a/shedskin/typestr.py
+++ b/shedskin/typestr.py
@@ -5,9 +5,13 @@ Copyright 2005-2013 Mark Dufour; License GNU GPL version 3 (See LICENSE)
 typestr.py: generate type declarations
 
 '''
+import logging
+
 import error
 import python
 import infer
+
+logger = logging.getLogger('typestr')
 
 
 class ExtmodError(Exception):
@@ -215,7 +219,7 @@ def typestrnew(gx, types, cplusplus=True, node=None, check_extmod=False, depth=0
     cl = lcp.pop()
 
     if check_ret and cl.mv.module.ident == 'collections' and cl.ident == 'defaultdict':
-        print '*WARNING* defaultdicts are returned as dicts'
+        logger.warn('defaultdicts are returned as dicts')
     elif check_extmod and cl.mv.module.builtin and not (cl.mv.module.ident == 'builtin' and cl.ident in ['int_', 'float_', 'complex', 'str_', 'list', 'tuple', 'tuple2', 'dict', 'set', 'frozenset', 'none', 'bool_']) and not (cl.mv.module.ident == 'collections' and cl.ident == 'defaultdict'):
         raise ExtmodError()
 


### PR DESCRIPTION
No more print statements to print debugging statements, warnings, or errors. This cleans up printing a bit and it allows us to redirect these to separate files as wanted. Setup for replacing the codegen printing with jinja2 templates.