### PR TITLE
Jinja: Start moving codegen to jinja2 templates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 blessings
 progressbar2
+jinja2

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     url='http://code.google.com/p/shedskin/',
     scripts=['scripts/shedskin'],
     cmdclass={'test': run_tests},
-    install_requires=['blessings', 'progressbar2'],
+    install_requires=['blessings', 'progressbar2', 'jinja2'],
     packages=['shedskin'],
     package_data={
         'shedskin': [

--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -458,7 +458,7 @@ class GenerateVisitor(ASTVisitor):
             node=node,
             module=self.module,
             imports=[
-                self.gx.from_module[child]
+                (child, self.gx.from_module[child])
                 for child in node.node.getChildNodes()
                 if isinstance(child, From) and child.modname != '__future__'],
             globals=self.gen_declare_defs(self.mv.globals.items()),

--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -108,6 +108,8 @@ class GenerateVisitor(ASTVisitor):
             trim_blocks=True,
             lstrip_blocks=True,
         )
+        self.jinja_env.filters['depointer'] = (
+            lambda ts: ts[:-1] if ts.endswith('*') else ts)
 
     def cpp_name(self, obj):
         return self.namer.name(obj)

--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -465,6 +465,8 @@ class GenerateVisitor(ASTVisitor):
             nodetypestr=lambda var: nodetypestr(self.gx, var, var.parent, mv=self.mv),
             defaults=self.gen_defaults(),
             listcomps=self.mv.listcomps,
+            cpp_name=self.cpp_name,
+            namer=self.namer,
         )
         print >>self.out, file_top
 

--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -9,9 +9,13 @@ output equivalent C++ code, using templates and virtuals to support data and OO 
 class GenerateVisitor: inherits visitor pattern from compiler.visitor.ASTVisitor, to recursively generate C++ code for each syntactical Python construct. the constraint graph, with inferred types, is first 'merged' back to program dimensions (gx.merged_inh).
 
 '''
+import os
 import string
 import struct
 import textwrap
+
+import jinja2
+
 from compiler import walk
 from compiler.ast import Const, AssTuple, AssList, From, Add, Stmt, AssAttr, \
     Keyword, AssName, CallFunc, Slice, Getattr, Dict, Subscript, \
@@ -98,6 +102,12 @@ class GenerateVisitor(ASTVisitor):
         self.with_count = 0
         self.bool_wrapper = {}
         self.namer = CPPNamer(self.gx, self)
+        self.jinja_env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(
+                os.path.dirname(__file__) + '/templates/cpp/'),
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
 
     def cpp_name(self, obj):
         return self.namer.name(obj)
@@ -289,18 +299,22 @@ class GenerateVisitor(ASTVisitor):
         else:
             return '->'
 
-    def declare_defs(self, vars, declare):
-        pairs = []
-        for (name, var) in vars:
-            if singletype(self.gx, var, Module) or var.invisible:
+    def gen_declare_defs(self, vars):
+        for name, var in vars:
+            if (singletype(self.gx, var, Module) or var.invisible
+                    or var.name in {'__exception', '__exception2'}):
                 continue
             ts = nodetypestr(self.gx, var, var.parent, mv=self.mv)
+            yield ts, self.cpp_name(var)
+
+    def declare_defs(self, vars, declare):
+        pairs = []
+        for ts, name in self.gen_declare_defs(vars):
             if declare:
                 if 'for_in_loop' in ts:  # XXX
                     continue
                 ts = 'extern ' + ts
-            if not var.name in ['__exception', '__exception2']:  # XXX
-                pairs.append((ts, self.cpp_name(var)))
+            pairs.append((ts, name))
         return ''.join(self.group_declarations(pairs))
 
     def get_constant(self, node):
@@ -348,7 +362,8 @@ class GenerateVisitor(ASTVisitor):
                 self.class_hpp(child)
 
         # --- defaults
-        self.defaults(declare=True)
+        for type, number in self.gen_defaults():
+            print >>self.out, 'extern %s default_%d;' % (type, number)
 
         # function declarations
         if self.module != self.gx.main_module:
@@ -375,14 +390,11 @@ class GenerateVisitor(ASTVisitor):
 
         print >>self.out, '#endif'
 
-    def defaults(self, declare):
-        if self.module.mv.defaults:
-            extern = ['', 'extern '][declare]
-            for default, (nr, func, func_def_nr) in self.module.mv.defaults.items():
-                formal = func.formals[len(func.formals) - len(func.defaults) + func_def_nr]
-                var = func.vars[formal]
-                print >>self.out, extern + typestr(self.gx, self.mergeinh[var], func, mv=self.mv) + ' ' + ('default_%d;' % nr)
-            print >>self.out
+    def gen_defaults(self):
+        for default, (nr, func, func_def_nr) in self.module.mv.defaults.items():
+            formal = func.formals[len(func.formals) - len(func.defaults) + func_def_nr]
+            var = func.vars[formal]
+            yield typestr(self.gx, self.mergeinh[var], func, mv=self.mv), nr  #  + ' ' + ('default_%d;' % nr)
 
     def init_defaults(self, func):
         for default in func.defaults:
@@ -440,47 +452,19 @@ class GenerateVisitor(ASTVisitor):
             print >>self.out, '}'
 
     def module_cpp(self, node):
-        print >>self.out, '#include "builtin.hpp"\n'
-
-        # --- comments
-        if node.doc:
-            self.do_comment(node.doc)
-            print >>self.out
-
-        # --- namespace fun
-        for n in self.module.name_list:
-            print >>self.out, 'namespace __' + n + '__ {'
-        print >>self.out
-
-        for child in node.node.getChildNodes():
-            if isinstance(child, From) and child.modname != '__future__':
-                module = self.gx.from_module[child]
-                using = 'using ' + module.full_path() + '::'
-                for (name, pseudonym) in child.names:
-                    pseudonym = pseudonym or name
-                    if name == '*':
-                        for func in module.mv.funcs.values():
-                            if func.cp:  # XXX
-                                print >>self.out, using + self.cpp_name(func) + ';'
-                        for cl in module.mv.classes.values():
-                            print >>self.out, using + self.cpp_name(cl) + ';'
-                    elif pseudonym not in self.module.mv.globals:
-                        if name in module.mv.funcs:
-                            func = module.mv.funcs[name]
-                            if func.cp:
-                                print >>self.out, using + self.cpp_name(func) + ';'
-                        else:
-                            print >>self.out, using + self.namer.nokeywords(name) + ';'
-        print >>self.out
-
-        # --- globals
-        defs = self.declare_defs(list(self.mv.globals.items()), declare=False)
-        if defs:
-            self.output(defs)
-            print >>self.out
-
-        # --- defaults
-        self.defaults(declare=False)
+        file_top = self.jinja_env.get_template('module.cpp.tpl').render(
+            node=node,
+            module=self.module,
+            imports=[
+                self.gx.from_module[child]
+                for child in node.node.getChildNodes()
+                if isinstance(child, From) and child.modname != '__future__'],
+            globals=self.gen_declare_defs(self.mv.globals.items()),
+            nodetypestr=lambda var: nodetypestr(self.gx, var, var.parent, mv=self.mv),
+            defaults=self.gen_defaults(),
+            listcomps=self.mv.listcomps,
+        )
+        print >>self.out, file_top
 
         # --- declarations
         self.listcomps = {}

--- a/shedskin/templates/cpp/imports.cpp.tpl
+++ b/shedskin/templates/cpp/imports.cpp.tpl
@@ -1,24 +1,28 @@
 {# imports -> using #}
-{% for child, child_module in imports %}
-{% set mod_name = child_module.full_path() %}
+{% for child, child_module in imports -%}
+{% set mod_name = child_module.full_path() -%}
 
-{% for name, pseudo in child.names %}
-{% if name == '*' %}
+{% for name, pseudo in child.names -%}
+{% set pseudo = pseudo or name -%}
+{% if name == '*' -%}
 
-{% for func in child_module.mv.funcs.values()|selectattr("cp") %}
-using {{ mod_name }}::{{cpp_name(func)}};
-{% endfor %}
+  {% for func in child_module.mv.funcs.values()|selectattr("cp") -%}
+    using {{ mod_name }}::{{cpp_name(func)}};
+  {% endfor %}
 
-{% for cl in child_module.mv.classes.values() %}
-using {{ mod_name }}::{{cpp_name(cl)}};
-{% endfor %}
+  {% for cl in child_module.mv.classes.values() -%}
+    using {{ mod_name }}::{{cpp_name(cl)}};
+  {% endfor %}
 
-{% elif pseudo not in module.mv.globals %}
-{% if name in child_module.mv.funcs %}
-using {{ mod_name }}::{{cpp_name(child_module.mv.funcs[name])}};
-{% else %}
-using {{ mod_name }}::{{namer.nokeywords(name)}};
-{% endif %}
+{% elif pseudo not in module.mv.globals -%}
+  {% if name in child_module.mv.funcs -%}
+    {% set func = child_module.mv.funcs[name] %}
+    {% if func.cp -%}
+      using {{ mod_name }}::{{cpp_name(func)}};
+    {% endif %}
+  {% else -%}
+    using {{ mod_name }}::{{namer.nokeywords(name)}};
+  {% endif %}
 {% endif %}
 
 {% endfor %}

--- a/shedskin/templates/cpp/imports.cpp.tpl
+++ b/shedskin/templates/cpp/imports.cpp.tpl
@@ -1,0 +1,24 @@
+{# imports -> using #}
+{% for child_module in imports %}
+
+{% for name, pseudo in child.names %}
+{% if name == '*' %}
+
+{% for func in child_module.mv.funcs.values()|selectattr("cp") %}
+using {{ child_module }}::{{cpp_name(func)}};
+{% endfor %}
+
+{% for cl in child_module.mv.classes.values() %}
+using {{ child_module }}::{{cpp_name(cl)}};
+{% endfor %}
+
+{% elif pseudo not in module.mv.globals %}
+{% if name in child_module.mv.funcs %}
+using {{ child_module }}::{{cpp_name(func)}};
+{% else %}
+using {{ child_module }}::{{namer.nokeywords(name)}};
+{% endif %}
+{% endif %}
+
+{% endfor %}
+{% endfor %}

--- a/shedskin/templates/cpp/imports.cpp.tpl
+++ b/shedskin/templates/cpp/imports.cpp.tpl
@@ -1,22 +1,23 @@
 {# imports -> using #}
 {% for child, child_module in imports %}
+{% set mod_name = child_module.full_path() %}
 
 {% for name, pseudo in child.names %}
 {% if name == '*' %}
 
 {% for func in child_module.mv.funcs.values()|selectattr("cp") %}
-using {{ child_module }}::{{cpp_name(func)}};
+using {{ mod_name }}::{{cpp_name(func)}};
 {% endfor %}
 
 {% for cl in child_module.mv.classes.values() %}
-using {{ child_module }}::{{cpp_name(cl)}};
+using {{ mod_name }}::{{cpp_name(cl)}};
 {% endfor %}
 
 {% elif pseudo not in module.mv.globals %}
 {% if name in child_module.mv.funcs %}
-using {{ child_module }}::{{cpp_name(func)}};
+using {{ mod_name }}::{{cpp_name(child_module.mv.funcs[name])}};
 {% else %}
-using {{ child_module }}::{{namer.nokeywords(name)}};
+using {{ mod_name }}::{{namer.nokeywords(name)}};
 {% endif %}
 {% endif %}
 

--- a/shedskin/templates/cpp/imports.cpp.tpl
+++ b/shedskin/templates/cpp/imports.cpp.tpl
@@ -1,5 +1,5 @@
 {# imports -> using #}
-{% for child_module in imports %}
+{% for child, child_module in imports %}
 
 {% for name, pseudo in child.names %}
 {% if name == '*' %}

--- a/shedskin/templates/cpp/module.cpp.tpl
+++ b/shedskin/templates/cpp/module.cpp.tpl
@@ -1,0 +1,49 @@
+#include "builtin.hpp"
+{% block docs %}
+{% if node.doc %}
+/**
+{% set doc = node.doc.replace('/*', '//').replace('*/', '//').split('\n') %}
+{% if doc[0].strip() %}{{ doc[0] }}{% endif %}
+{% set lines = dedent('\n'.join(doc[1:])).splitlines() %}
+{% for line in lines %}
+{{ line }}
+{% endfor %}
+*/
+
+{% endif %}
+{% endblock %}
+
+{% block namespaces %}
+{% for name in module.name_list %}
+namespace __{{name}}__ {
+{% endfor %}
+{% endblock %}
+
+{% block imports %}
+{% include "imports.cpp.tpl" %}
+{% endblock %}
+
+{% block globals %}
+{% for type, vars in globals|groupby(0) %}
+{# group variables of the same type together, but watch out for pointers #}
+{% set pointer = '*' if type.endswith('*') else '' -%}
+
+{{ type|replace('*', '') }}
+{%- for var in vars -%}
+  {% if not loop.first %}, {% endif -%}
+  {{ pointer }}{{ var[1] }}
+{%- endfor -%};
+{% endfor -%}
+{% endblock %}
+
+{% block defaults %}
+{% for type, number in defaults %}
+{{type}} default_{{number}};
+{% endfor %}
+{% endblock %}
+
+{% block end_namespaces %}
+{% for name in module.name_list %}
+{# } #}
+{% endfor %}
+{% endblock %}

--- a/shedskin/templates/cpp/module.cpp.tpl
+++ b/shedskin/templates/cpp/module.cpp.tpl
@@ -28,7 +28,7 @@ namespace __{{name}}__ {
 {# group variables of the same type together, but watch out for pointers #}
 {% set pointer = '*' if type.endswith('*') else '' -%}
 
-{{ type|replace('*', '') }}
+{{ type|depointer }}
 {%- for var in vars -%}
   {% if not loop.first %}, {% endif -%}
   {{ pointer }}{{ var[1] }}


### PR DESCRIPTION
I thought it would be potentially useful to split out the codegen into templates that allow overriding parts. This would ease tweaking and experimentation, but also allow multiple 'backends' to exist, such as a C++11 backend, if we refactor the templates out correctly.

This is just a start, it only outputs the top few bits through jinja and the rest isn't touched. Due to the way groupby in jinja works (it sorts), the output variables are in a different order, but otherwise I've tested the output to be the same.