### PR TITLE
Add str::c_str so that we can remove all instances of unit

### DIFF
--- a/examples/lib/hashlib.cpp
+++ b/examples/lib/hashlib.cpp
@@ -17,8 +17,8 @@ str *md5::hexdigest() {
     MD5((unsigned char *)data->unit.data(), data->unit.size(), (unsigned char *)digest->unit.data());
     str *hexdigest = new str();
     for(int i=0; i<16; i++) {
-        hexdigest->unit.push_back(__str((digest->unit[i]>>4) & 0xf, 16)->unit[0]);
-        hexdigest->unit.push_back(__str(digest->unit[i] & 0xf, 16)->unit[0]);
+        hexdigest->push_back(__str((digest->unit[i]>>4) & 0xf, 16)->unit[0]);
+        hexdigest->push_back(__str(digest->unit[i] & 0xf, 16)->unit[0]);
     }
     return hexdigest;
 }

--- a/shedskin/extmod.py
+++ b/shedskin/extmod.py
@@ -242,7 +242,7 @@ def do_extmod_method(gx, gv, func):
 
     # convert exceptions
     print >>gv.out, '    } catch (Exception *e) {'
-    print >>gv.out, '        PyErr_SetString(__to_py(e), ((e->message)?(e->message->unit.c_str()):""));'
+    print >>gv.out, '        PyErr_SetString(__to_py(e), ((e->message)?(e->message->c_str()):""));'
     print >>gv.out, '        return 0;'
     print >>gv.out, '    }'
     print >>gv.out, '}\n'
@@ -368,7 +368,7 @@ def do_extmod_class(gx, gv, cl):
         else:
             print >>gv.out, '        self->__ss_object->%s = __to_ss<%s>(value);' % (gv.cpp_name(var), typ)
         print >>gv.out, '    } catch (Exception *e) {'
-        print >>gv.out, '        PyErr_SetString(__to_py(e), ((e->message)?(e->message->unit.c_str()):""));'
+        print >>gv.out, '        PyErr_SetString(__to_py(e), ((e->message)?(e->message->c_str()):""));'
         print >>gv.out, '        return -1;'
         print >>gv.out, '    }'
 

--- a/shedskin/lib/array.cpp
+++ b/shedskin/lib/array.cpp
@@ -19,14 +19,14 @@ void __throw_no_char() {
 }
 
 template<> void *array<str *>::append(str *t) {
-    if(t->unit.size() != 1)
+    if(t->size() != 1)
         __throw_no_char();
     units.push_back(t->unit[0]);
     return NULL;
 }
 
 template<> void *array<str *>::__setitem__(__ss_int i, str *t) {
-    if(t->unit.size() != 1)
+    if(t->size() != 1)
         __throw_no_char();
     i = __wrap(this, i);
     units[i*itemsize] = t->unit[0];

--- a/shedskin/lib/array.hpp
+++ b/shedskin/lib/array.hpp
@@ -128,7 +128,7 @@ template<class T> str *array<T>::tostring() {
 }
 
 template<class T> void *array<T>::fromstring(str *s) {
-    size_t len = s->unit.size();
+    size_t len = s->size();
     if(len == 1)
         this->units.push_back(s->unit[0]);
     else {

--- a/shedskin/lib/builtin.hpp
+++ b/shedskin/lib/builtin.hpp
@@ -365,6 +365,7 @@ public:
 
     /* functions pointing to the underlying C++ implementation */
     const char *c_str() const;
+    const int size() const;
 
     str *__str__();
     str *__repr__();

--- a/shedskin/lib/builtin.hpp
+++ b/shedskin/lib/builtin.hpp
@@ -352,6 +352,9 @@ public:
 
     template<class U> str *join(U *);
 
+    /* functions pointing to the underlying C++ implementation */
+    const char *c_str() const;
+
     str *__str__();
     str *__repr__();
     str *__mul__(__ss_int n);

--- a/shedskin/lib/builtin.hpp
+++ b/shedskin/lib/builtin.hpp
@@ -332,6 +332,7 @@ public:
 };
 
 class str : public pyseq<str *> {
+protected:
 public:
     __GC_STRING unit;
     long hash;
@@ -351,6 +352,16 @@ public:
     str *__add__(str *b);
 
     template<class U> str *join(U *);
+
+    /* operators */
+    //inline void operator+= (const char *c);
+    str *operator+ (const char *c);
+    str *operator+ (const char &c);
+    void operator+= (const char *c);
+    void operator+= (const char &c);
+    //str *operator+ (const char c);
+    //str *operator+ (str *c);
+    //str *operator+ (basic_string c);
 
     /* functions pointing to the underlying C++ implementation */
     const char *c_str() const;

--- a/shedskin/lib/builtin.hpp
+++ b/shedskin/lib/builtin.hpp
@@ -366,6 +366,8 @@ public:
     /* functions pointing to the underlying C++ implementation */
     const char *c_str() const;
     const int size() const;
+    const int find(const char c, int a=0) const;
+    const int find(const char *c, int a=0) const;
 
     str *__str__();
     str *__repr__();

--- a/shedskin/lib/builtin/bool.hpp
+++ b/shedskin/lib/builtin/bool.hpp
@@ -17,7 +17,7 @@ template<class T> inline __ss_bool ___bool(T x) { return __mbool(x && x->__nonze
 #ifdef __SS_LONG
 template<> inline __ss_bool ___bool(__ss_int x) { return __mbool(x!=0); }
 #endif
-template<> inline __ss_bool ___bool(str *s) { return __mbool(s && s->unit.size() > 0); }
+template<> inline __ss_bool ___bool(str *s) { return __mbool(s && s->size() > 0); }
 template<> inline __ss_bool ___bool(int x) { return __mbool(x!=0); }
 template<> inline __ss_bool ___bool(bool x) { return __mbool(x); }
 template<> inline __ss_bool ___bool(__ss_bool x) { return x; }

--- a/shedskin/lib/builtin/dict.hpp
+++ b/shedskin/lib/builtin/dict.hpp
@@ -548,18 +548,20 @@ template <class K, class V> void dict<K,V>::resize(int minused)
 template<class K, class V> str *dict<K,V>::__repr__() {
     str *r = new str("{");
     dictentry<K,V> *entry;
-    
+
     int i = __len__();
     __ss_int pos = 0;
 
     while (next(&pos, &entry)) {
 		--i;
-        r->unit += repr(entry->key)->unit + ": " + repr(entry->value)->unit;
+        *r += repr(entry->key)->c_str();
+        *r += ": ";
+        *r += repr(entry->value)->c_str();
         if( i > 0 )
-           r->unit += ", ";
+            *r += ", ";
     }
 
-    r->unit += "}";
+    r = *r + "}";
     return r;
 }
 

--- a/shedskin/lib/builtin/file.cpp
+++ b/shedskin/lib/builtin/file.cpp
@@ -49,7 +49,7 @@ file *open(str *name, str *flags) {
 void *file::write(str *s) {
     __check_closed();
     if(f) {
-        size_t size = s->unit.size();
+        size_t size = s->size();
         if(FWRITE(s->unit.data(), 1, size, f) != size and __error())
             throw new IOError();
     }

--- a/shedskin/lib/builtin/file.cpp
+++ b/shedskin/lib/builtin/file.cpp
@@ -35,7 +35,7 @@ file::file(str *file_name, str *flags) {
     }
     else
         flags = __char_cache['r'];
-    f = fopen(file_name->unit.c_str(), flags->unit.c_str());
+    f = fopen(file_name->c_str(), flags->c_str());
     if(f == 0)
         throw new IOError(file_name);
     name = file_name;

--- a/shedskin/lib/builtin/format.cpp
+++ b/shedskin/lib/builtin/format.cpp
@@ -135,7 +135,7 @@ void __modfill(str **fmt, pyobj *t, str **s, pyobj *a1, pyobj *a2) {
         }
         add = do_asprintf((*fmt)->unit.substr(i, j+1-i).c_str(), ((float_ *)t)->unit, a1, a2);
         if(c == 'H' && ((float_ *)t)->unit-((int)(((float_ *)t)->unit)) == 0)
-            add->unit += ".0";
+            *add += ".0";
     }
     *s = (*s)->__add__(add);
     *fmt = new str((*fmt)->unit.substr(j+1, (*fmt)->size()-j-1));
@@ -150,7 +150,7 @@ pyobj *modgetitem(list<pyobj *> *vals, int i) {
 str *__mod4(str *fmts, list<pyobj *> *vals) {
     int i, j;
     str *r = new str();
-    str *fmt = new str(fmts->unit);
+    str *fmt = new str(fmts->c_str());
     i = 0;
     while((j = __fmtpos(fmt)) != -1) {
         pyobj *p, *a1, *a2;
@@ -165,7 +165,7 @@ str *__mod4(str *fmts, list<pyobj *> *vals) {
             a2 = modgetitem(vals, i++);
         }
 
-        char c = fmt->unit[j];
+        char c = fmt->c_str()[j];
         if(c != '%')
             p = modgetitem(vals, i++);
     
@@ -204,7 +204,7 @@ str *__mod4(str *fmts, list<pyobj *> *vals) {
     if(i!=len(vals))
         throw new TypeError(new str("not all arguments converted during string formatting"));
 
-    r->unit += fmt->unit;
+    *r += fmt->c_str();
     return r;
 }
 
@@ -339,10 +339,10 @@ void print2(file *f, int comma, int n, ...) {
     __file_options *p_opt = &f->options;
     str *s = __mod5(__print_cache, sp);
     if(len(s)) {
-        if(p_opt->space && (!isspace(p_opt->lastchar) || p_opt->lastchar==' ') && s->unit[0] != '\n') 
+        if(p_opt->space && (!isspace(p_opt->lastchar) || p_opt->lastchar==' ') && s->c_str()[0] != '\n')
             f->write(sp); /* space */
         f->write(s);
-        p_opt->lastchar = s->unit[len(s)-1];
+        p_opt->lastchar = s->c_str()[len(s)-1];
     }
     else if (comma)
         p_opt->lastchar = ' ';

--- a/shedskin/lib/builtin/format.cpp
+++ b/shedskin/lib/builtin/format.cpp
@@ -41,7 +41,7 @@ int asprintf(char **ret, const char *format, ...)
 #endif
 
 int __fmtpos(str *fmt) {
-    int i = fmt->unit.find('%');
+    int i = fmt->find('%');
     if(i == -1)
         return -1;
     return fmt->unit.find_first_not_of(__fmtchars, i+1);
@@ -49,7 +49,7 @@ int __fmtpos(str *fmt) {
 
 int __fmtpos2(str *fmt) {
     unsigned int i = 0;
-    while((i = fmt->unit.find('%', i)) != -1) {
+    while((i = fmt->find('%', i)) != -1) {
         if(i != fmt->size()-1) {
             char nextchar = fmt->unit[i+1];
             if(nextchar == '%')
@@ -82,7 +82,7 @@ str *do_asprintf_str(const char *fmt, str *s, pyobj *a1, pyobj *a2) {
     char *d;
     int x;
     str *r;
-    int nullchars = (s->unit.find('\0') != -1); /* XXX %6.s */
+    int nullchars = (s->find('\0') != -1); /* XXX %6.s */
     ssize_t len = s->size();
     str *old_s = s;
     if(nullchars) {
@@ -107,7 +107,7 @@ str *do_asprintf_str(const char *fmt, str *s, pyobj *a1, pyobj *a2) {
 
 void __modfill(str **fmt, pyobj *t, str **s, pyobj *a1, pyobj *a2) {
     char c;
-    int i = (*fmt)->unit.find('%');
+    int i = (*fmt)->find('%');
     int j = __fmtpos(*fmt);
     *s = new str((*s)->unit + (*fmt)->unit.substr(0, i));
     str *add;
@@ -155,7 +155,7 @@ str *__mod4(str *fmts, list<pyobj *> *vals) {
     while((j = __fmtpos(fmt)) != -1) {
         pyobj *p, *a1, *a2;
 
-        int perc_pos = fmt->unit.find('%');
+        int perc_pos = fmt->find('%');
         int asterisks = std::count(fmt->unit.begin()+perc_pos+1, fmt->unit.begin()+j, '*');
         a1 = a2 = NULL;
         if(asterisks==1) {

--- a/shedskin/lib/builtin/format.cpp
+++ b/shedskin/lib/builtin/format.cpp
@@ -90,11 +90,11 @@ str *do_asprintf_str(const char *fmt, str *s, pyobj *a1, pyobj *a2) {
         std::replace(s->unit.begin(), s->unit.end(), '\0', ' ');
     }
     if(a2)
-        x = asprintf(&d, fmt, ((int)(((int_ *)a1)->unit)), ((int)(((int_ *)a2)->unit)), s->unit.c_str());
+        x = asprintf(&d, fmt, ((int)(((int_ *)a1)->unit)), ((int)(((int_ *)a2)->unit)), s->c_str());
     else if(a1)
-        x = asprintf(&d, fmt, ((int)(((int_ *)a1)->unit)), s->unit.c_str());
+        x = asprintf(&d, fmt, ((int)(((int_ *)a1)->unit)), s->c_str());
     else
-        x = asprintf(&d, fmt, s->unit.c_str());
+        x = asprintf(&d, fmt, s->c_str());
     if(nullchars) {
         for(int i=0; i<x && i<len; i++)
             if(old_s->unit[i] == '\0')
@@ -324,7 +324,7 @@ void print(int n, file *f, str *end, str *sep, ...) {
         f->write(end);
     }
     else 
-        printf("%s%s", s->unit.c_str(), end->unit.c_str());
+        printf("%s%s", s->c_str(), end->c_str());
 }
 
 void print2(file *f, int comma, int n, ...) {

--- a/shedskin/lib/builtin/format.cpp
+++ b/shedskin/lib/builtin/format.cpp
@@ -50,7 +50,7 @@ int __fmtpos(str *fmt) {
 int __fmtpos2(str *fmt) {
     unsigned int i = 0;
     while((i = fmt->unit.find('%', i)) != -1) {
-        if(i != fmt->unit.size()-1) {
+        if(i != fmt->size()-1) {
             char nextchar = fmt->unit[i+1];
             if(nextchar == '%')
                 i++;
@@ -83,7 +83,7 @@ str *do_asprintf_str(const char *fmt, str *s, pyobj *a1, pyobj *a2) {
     int x;
     str *r;
     int nullchars = (s->unit.find('\0') != -1); /* XXX %6.s */
-    ssize_t len = s->unit.size();
+    ssize_t len = s->size();
     str *old_s = s;
     if(nullchars) {
         s = new str(s->unit);
@@ -138,7 +138,7 @@ void __modfill(str **fmt, pyobj *t, str **s, pyobj *a1, pyobj *a2) {
             add->unit += ".0";
     }
     *s = (*s)->__add__(add);
-    *fmt = new str((*fmt)->unit.substr(j+1, (*fmt)->unit.size()-j-1));
+    *fmt = new str((*fmt)->unit.substr(j+1, (*fmt)->size()-j-1));
 }
 
 pyobj *modgetitem(list<pyobj *> *vals, int i) {

--- a/shedskin/lib/builtin/function.cpp
+++ b/shedskin/lib/builtin/function.cpp
@@ -19,16 +19,16 @@ __ss_int __int(str *s, __ss_int base) {
     char *cp;
     __ss_int i;
 #ifdef __SS_LONG
-    i = strtoll(s->unit.c_str(), &cp, base);
+    i = strtoll(s->c_str(), &cp, base);
 #else
-    i = strtol(s->unit.c_str(), &cp, base);
+    i = strtol(s->c_str(), &cp, base);
 #endif
     if(*cp != '\0') {
         s = s->rstrip();
         #ifdef __SS_LONG
-            i = strtoll(s->unit.c_str(), &cp, base);
+            i = strtoll(s->c_str(), &cp, base);
         #else
-            i = strtol(s->unit.c_str(), &cp, base);
+            i = strtol(s->c_str(), &cp, base);
         #endif
         if(*cp != '\0')
             throw new ValueError(new str("invalid literal for int()"));
@@ -37,7 +37,7 @@ __ss_int __int(str *s, __ss_int base) {
 }
 
 template<> double __float(str *s) {
-    return strtod(s->unit.c_str(), NULL);
+    return strtod(s->c_str(), NULL);
 }
 
 template<> __ss_int id(__ss_int) { throw new TypeError(new str("'id' called with integer")); }

--- a/shedskin/lib/builtin/function.hpp
+++ b/shedskin/lib/builtin/function.hpp
@@ -490,9 +490,9 @@ template <class B> str *filter(B (*func)(str *), str *a) {
         if(func) {
             c = __char_cache[((unsigned char)e)];
             if(___bool((*func)(c)))
-                result->unit.push_back(e);
+                result->push_back(e);
         } else 
-            result->unit.push_back(e);
+            result->push_back(e);
     }
     return result;
 }

--- a/shedskin/lib/builtin/function.hpp
+++ b/shedskin/lib/builtin/function.hpp
@@ -536,7 +536,7 @@ static void __throw_ord_exc(size_t s) { /* improve inlining */
 }
 
 inline __ss_int ord(str *s) {
-    size_t len = s->unit.size();
+    size_t len = s->size();
     if(len != 1)
         __throw_ord_exc(len);
     return (unsigned char)(s->unit[0]);

--- a/shedskin/lib/builtin/function.hpp
+++ b/shedskin/lib/builtin/function.hpp
@@ -486,13 +486,13 @@ template <class B> str *filter(B (*func)(str *), str *a) {
     char e;
     str *c;
     for(int i=0; i<size; i++) {
-        e = a->unit[i];
+        e = a->c_str()[i];
         if(func) {
             c = __char_cache[((unsigned char)e)];
             if(___bool((*func)(c)))
-                result->push_back(e);
-        } else 
-            result->push_back(e);
+                *result += e;
+        } else
+            *result += e;
     }
     return result;
 }
@@ -539,7 +539,7 @@ inline __ss_int ord(str *s) {
     size_t len = s->size();
     if(len != 1)
         __throw_ord_exc(len);
-    return (unsigned char)(s->unit[0]);
+    return (unsigned char)(s->c_str()[0]);
 }
 
 static void __throw_chr_out_of_range() { /* improve inlining */

--- a/shedskin/lib/builtin/list.hpp
+++ b/shedskin/lib/builtin/list.hpp
@@ -336,11 +336,11 @@ template<class T> str *list<T>::__repr__() {
     str *r = new str("[");
     int len = this->__len__();
     for(int i = 0; i<len;i++) {
-        r->unit += repr(units[i])->unit;
+        *r += repr(units[i])->c_str();
         if (i<len-1)
-            r->unit += ", ";
+            *r += ", ";
     }
-    r->unit += "]";
+    *r += "]";
     return r;
 }
 

--- a/shedskin/lib/builtin/list.hpp
+++ b/shedskin/lib/builtin/list.hpp
@@ -41,7 +41,7 @@ template<class T> list<T>::list(tuple2<T, T> *p) {
 template<class T> list<T>::list(str *s) {
     this->__class__ = cl_list;
     this->units.resize(len(s));
-    int sz = s->unit.size();
+    int sz = s->size();
     for(int i=0; i<sz; i++)
         this->units[i] = __char_cache[((unsigned char)(s->unit[i]))];
 }
@@ -125,7 +125,7 @@ template<class T> void *list<T>::extend(tuple2<T,T> *p) {
 }
 
 template<class T> void *list<T>::extend(str *s) {
-    int sz = s->unit.size();
+    int sz = s->size();
     for(int i=0; i<sz; i++)
         this->units.push_back(__char_cache[((unsigned char)(s->unit[i]))]);
     return NULL;

--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -22,6 +22,10 @@ str *str::__str__() { // weg?
     return this;
 }
 
+const char *str::c_str() const {
+    return this->unit.c_str();
+}
+
 str *str::__repr__() {
     std::stringstream ss;
     __GC_STRING sep = "\\\n\r\t";
@@ -309,7 +313,7 @@ list<str *> *str::split(str *sp, int max_splits) {
 
     } else { /* given separator (slightly different algorithm required)
               * (python is very inconsistent in this respect) */
-        const char *sep = sp->unit.c_str();
+        const char *sep = sp->c_str();
         int sep_size = sp->unit.size();
 
 #define next_separator(iter) s.find(sep, (iter))
@@ -786,7 +790,7 @@ str::str(PyObject *p) : hash(-1) {
 }
 
 PyObject *str::__to_py__() {
-    return PyString_FromStringAndSize(unit.c_str(), unit.size());
+    return PyString_FromStringAndSize(c_str(), unit.size());
 }
 #endif
 

--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -26,6 +26,10 @@ const char *str::c_str() const {
     return this->unit.c_str();
 }
 
+const int str::size() const {
+    return this->unit.size();
+}
+
 str *str::__repr__() {
     std::stringstream ss;
     __GC_STRING sep = "\\\n\r\t";
@@ -42,7 +46,7 @@ str *str::__repr__() {
         quote = "\"";
 
     ss << quote;
-    for(unsigned int i=0; i<unit.size(); i++)
+    for(unsigned int i=0; i<size(); i++)
     {
         char c = unit[i];
         int k;
@@ -93,7 +97,7 @@ void str::operator+= (const char &rhs) {
 
 __ss_bool str::__ctype_function(int (*cfunc)(int))
 {
-  int i, l = unit.size();
+  int i, l = size();
   if(!l)
       return False;
 
@@ -103,7 +107,7 @@ __ss_bool str::__ctype_function(int (*cfunc)(int))
   return True;
 }
 
-__ss_bool str::isspace() { return __mbool(unit.size() && (unit.find_first_not_of(ws) == std::string::npos)); }
+__ss_bool str::isspace() { return __mbool(size() && (unit.find_first_not_of(ws) == std::string::npos)); }
 __ss_bool str::isdigit() { return __ctype_function(&::isdigit); }
 __ss_bool str::isalpha() { return __ctype_function(&::isalpha); }
 __ss_bool str::isalnum() { return __ctype_function(&::isalnum); }
@@ -146,7 +150,7 @@ str *str::lstrip(str *chars) {
     int first = unit.find_first_not_of(remove);
     if( first == -1 )
         return new str("");
-    return new str(unit.substr(first,unit.size()-first));
+    return new str(unit.substr(first,size()-first));
 }
 
 
@@ -180,7 +184,7 @@ list<str *> *str::rsplit(str *sep, int maxsep)
     int i, j, curi, tslen;
 
     curi = 0;
-    i = j = unit.size() - 1;
+    i = j = size() - 1;
 
     //split by whitespace
     if(!sep)
@@ -238,7 +242,7 @@ __ss_bool str::istitle()
 {
     int i, len;
 
-    len = unit.size();
+    len = size();
     if(!len)
         return False;
 
@@ -281,7 +285,7 @@ list<str *> *str::splitlines(int keepends)
     }
     while(i >= 0);
 
-    if(j != unit.size()) r->append(new str(unit.substr(j)));
+    if(j != size()) r->append(new str(unit.substr(j)));
 
     return r;
 }
@@ -332,7 +336,7 @@ list<str *> *str::split(str *sp, int max_splits) {
     } else { /* given separator (slightly different algorithm required)
               * (python is very inconsistent in this respect) */
         const char *sep = sp->c_str();
-        int sep_size = sp->unit.size();
+        int sep_size = sp->size();
 
 #define next_separator(iter) s.find(sep, (iter))
 #define skip_separator(iter) ((iter + sep_size) > s.size()? -1 : (iter + sep_size))
@@ -377,7 +381,7 @@ str *str::translate(str *table, str *delchars) {
 
     str *newstr = new str();
 
-    int self_size = unit.size();
+    int self_size = size();
     for(int i = 0; i < self_size; i++) {
         char c = unit[i];
         if(!delchars || delchars->unit.find(c) == std::string::npos)
@@ -428,8 +432,8 @@ __ss_int str::__cmp__(pyobj *p) {
 
 __ss_bool str::__eq__(pyobj *p) {
     str *q = (str *)p;
-    size_t len = unit.size();
-    if(len != q->unit.size() or (hash != -1 and q->hash != -1 and hash != q->hash))
+    size_t len = size();
+    if(len != q->size() or (hash != -1 and q->hash != -1 and hash != q->hash))
         return False;
     return __mbool(memcmp(unit.data(), q->unit.data(), len) == 0);
 }
@@ -438,7 +442,7 @@ str *str::__mul__(__ss_int n) { /* optimize */
     str *r = new str();
     if(n<=0) return r;
     __GC_STRING &s = r->unit;
-    __ss_int ulen = unit.size();
+    __ss_int ulen = size();
 
     if(ulen == 1)
        r->unit = __GC_STRING(n, unit[0]);
@@ -539,7 +543,7 @@ long str::__hash__() {
 str *str::__add__(str *b) {
     str *s = new str();
 
-    s->unit.reserve(unit.size()+b->unit.size());
+    s->unit.reserve(size()+b->size());
     s->unit.append(unit);
     s->unit.append(b->unit);
 
@@ -551,9 +555,9 @@ str *str::__iadd__(str *b) {
 
 str *__add_strs(int, str *a, str *b, str *c) {
     str *result = new str();
-    int asize = a->unit.size();
-    int bsize = b->unit.size();
-    int csize = c->unit.size();
+    int asize = a->size();
+    int bsize = b->size();
+    int csize = c->size();
     if(asize == 1 && bsize == 1 && csize == 1) {
         result->unit.resize(3);
         result->unit[0] = a->unit[0];
@@ -573,10 +577,10 @@ str *__add_strs(int, str *a, str *b, str *c) {
 
 str *__add_strs(int, str *a, str *b, str *c, str *d) {
     str *result = new str();
-    int asize = a->unit.size();
-    int bsize = b->unit.size();
-    int csize = c->unit.size();
-    int dsize = d->unit.size();
+    int asize = a->size();
+    int bsize = b->size();
+    int csize = c->size();
+    int dsize = d->size();
     if(asize == 1 && bsize == 1 && csize == 1 && dsize == 1) {
         result->unit.resize(4);
         result->unit[0] = a->unit[0];
@@ -599,11 +603,11 @@ str *__add_strs(int, str *a, str *b, str *c, str *d) {
 
 str *__add_strs(int, str *a, str *b, str *c, str *d, str *e) {
     str *result = new str();
-    int asize = a->unit.size();
-    int bsize = b->unit.size();
-    int csize = c->unit.size();
-    int dsize = d->unit.size();
-    int esize = e->unit.size();
+    int asize = a->size();
+    int bsize = b->size();
+    int csize = c->size();
+    int dsize = d->size();
+    int esize = e->size();
     if(asize == 1 && bsize == 1 && csize == 1 && dsize == 1 && esize == 1) {
         result->unit.resize(5);
         result->unit[0] = a->unit[0];
@@ -648,8 +652,8 @@ str *__add_strs(int n, ...) {
     for(int i=0; i<n; i++) {
         str *s = va_arg(ap, str *);
 
-        memcpy((void *)(result->unit.data()+pos), s->unit.data(), s->unit.size());
-        pos += s->unit.size();
+        memcpy((void *)(result->unit.data()+pos), s->unit.data(), s->size());
+        pos += s->size();
     }
     va_end(ap);
 
@@ -657,7 +661,7 @@ str *__add_strs(int n, ...) {
 }
 
 str *str::__slice__(__ss_int x, __ss_int l, __ss_int u, __ss_int s) {
-    int len = unit.size();
+    int len = size();
     slicenr(x, l, u, s, len);
     if(s == 1)
         return new str(unit.data()+l, u-l);
@@ -683,10 +687,10 @@ int str::__fixstart(int a, int b) {
     return a+b;
 }
 
-int str::find(str *s, int a) { return __fixstart(unit.substr(a, unit.size()-a).find(s->unit), a); }
+int str::find(str *s, int a) { return __fixstart(unit.substr(a, size()-a).find(s->unit), a); }
 int str::find(str *s, int a, int b) { return __fixstart(unit.substr(a, b-a).find(s->unit), a); }
 
-int str::rfind(str *s, int a) { return __fixstart(unit.substr(a, unit.size()-a).rfind(s->unit), a); }
+int str::rfind(str *s, int a) { return __fixstart(unit.substr(a, size()-a).rfind(s->unit), a); }
 int str::rfind(str *s, int a, int b) { return __fixstart(unit.substr(a, b-a).rfind(s->unit), a); }
 
 int str::__checkneg(int i) {
@@ -743,8 +747,8 @@ __ss_bool str::endswith(str *s, __ss_int start, __ss_int end) {
 str *str::replace(str *a, str *b, int c) {
     __GC_STRING s = unit;
     int i, j, p;
-    int asize = a->unit.size();
-    int bsize = b->unit.size();
+    int asize = a->size();
+    int bsize = b->size();
     j = p = 0;
     while( ((c==-1) || (j++ != c)) && (i = s.find(a->unit, p)) != -1 ) {
       s.replace(i, asize, b->unit);
@@ -754,7 +758,7 @@ str *str::replace(str *a, str *b, int c) {
 }
 
 str *str::upper() {
-    if(unit.size() == 1)
+    if(size() == 1)
         return __char_cache[((unsigned char)(::toupper(unit[0])))];
 
     str *toReturn = new str(*this);
@@ -764,7 +768,7 @@ str *str::upper() {
 }
 
 str *str::lower() {
-    if(unit.size() == 1)
+    if(size() == 1)
         return __char_cache[((unsigned char)(::tolower(unit[0])))];
 
     str *toReturn = new str(*this);
@@ -776,7 +780,7 @@ str *str::lower() {
 str *str::title() {
     str *r = new str(unit);
     bool up = true;
-    size_t len = this->unit.size();
+    size_t len = this->size();
     for(size_t i=0; i<len; i++) {
         char c = this->unit[i];
         if(!::isalpha(c))
@@ -808,7 +812,7 @@ str::str(PyObject *p) : hash(-1) {
 }
 
 PyObject *str::__to_py__() {
-    return PyString_FromStringAndSize(c_str(), unit.size());
+    return PyString_FromStringAndSize(c_str(), size());
 }
 #endif
 

--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -393,7 +393,7 @@ str *str::translate(str *table, str *delchars) {
     for(int i = 0; i < self_size; i++) {
         char c = unit[i];
         if(!delchars || delchars->find(c) == std::string::npos)
-            newstr->unit.push_back(table->unit[(unsigned char)c]);
+            newstr->push_back(table->unit[(unsigned char)c]);
     }
 
     return newstr;

--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -393,7 +393,7 @@ str *str::translate(str *table, str *delchars) {
     for(int i = 0; i < self_size; i++) {
         char c = unit[i];
         if(!delchars || delchars->find(c) == std::string::npos)
-            newstr->push_back(table->unit[(unsigned char)c]);
+            *newstr += table->unit[(unsigned char)c];
     }
 
     return newstr;

--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -73,6 +73,24 @@ __ss_bool str::__contains__(str *s) {
     return __mbool(unit.find(s->unit) != std::string::npos);
 }
 
+str *str::operator+ (const char *rhs) {
+    str *ret = new str(this->unit + rhs);
+    return ret;
+}
+
+str *str::operator+ (const char &rhs) {
+    str *ret = new str(this->unit + rhs);
+    return ret;
+}
+
+void str::operator+= (const char *rhs) {
+    this->unit += rhs;
+}
+
+void str::operator+= (const char &rhs) {
+    this->unit += rhs;
+}
+
 __ss_bool str::__ctype_function(int (*cfunc)(int))
 {
   int i, l = unit.size();

--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -30,14 +30,22 @@ const int str::size() const {
     return this->unit.size();
 }
 
+const int str::find(const char c, int a) const {
+    return this->unit.find(c, a);
+}
+
+const int str::find(const char *c, int a) const {
+    return this->unit.find(c, a);
+}
+
 str *str::__repr__() {
     std::stringstream ss;
     __GC_STRING sep = "\\\n\r\t";
     __GC_STRING let = "\\nrt";
 
     const char *quote = "'";
-    int hasq = unit.find("'");
-    int hasd = unit.find("\"");
+    int hasq = find('\'');
+    int hasd = find('\"');
 
     if (hasq != -1 && hasd != -1) {
         sep += "'"; let += "'";
@@ -74,7 +82,7 @@ __ss_int str::__int__() {
 }
 
 __ss_bool str::__contains__(str *s) {
-    return __mbool(unit.find(s->unit) != std::string::npos);
+    return __mbool(find(s) != std::string::npos);
 }
 
 str *str::operator+ (const char *rhs) {
@@ -159,7 +167,7 @@ tuple2<str *, str *> *str::partition(str *sep)
 {
     int i;
 
-    i = unit.find(sep->unit);
+    i = find(sep->c_str());
     if(i != -1)
         return new tuple2<str *, str *>(3, new str(unit.substr(0, i)), new str(sep->unit), new str(unit.substr(i + sep->unit.length())));
     else
@@ -384,7 +392,7 @@ str *str::translate(str *table, str *delchars) {
     int self_size = size();
     for(int i = 0; i < self_size; i++) {
         char c = unit[i];
-        if(!delchars || delchars->unit.find(c) == std::string::npos)
+        if(!delchars || delchars->find(c) == std::string::npos)
             newstr->unit.push_back(table->unit[(unsigned char)c]);
     }
 
@@ -711,7 +719,7 @@ __ss_int str::count(str *s, __ss_int start, __ss_int end) {
     slicenr(7, start, end, one, __len__());
 
     i = start; count = 0;
-    while( ((i = unit.find(s->unit, i)) != -1) && (i <= end-len(s)) )
+    while( ((i = find(s->c_str(), i)) != -1) && (i <= end-len(s)) )
     {
         i += len(s);
         count++;

--- a/shedskin/lib/builtin/str.hpp
+++ b/shedskin/lib/builtin/str.hpp
@@ -13,11 +13,11 @@ inline str *str::__getfast__(__ss_int i) {
 }
 
 inline __ss_int str::__len__() {
-    return unit.size();
+    return size();
 }
 
 inline bool str::for_in_has_next(size_t i) {
-    return i < unit.size(); /* XXX opt end cond */
+    return i < size(); /* XXX opt end cond */
 }
 
 inline str *str::for_in_next(size_t &i) {
@@ -34,12 +34,12 @@ template <class U> str *str::join(U *iter) {
     total = 0;
     FOR_IN(e,iter,1,2,3)
         __join_cache->units.push_back(e);
-        sz = e->unit.size();
+        sz = e->size();
         if(sz != 1)
             only_ones = false;
         total += sz;
     END_FOR
-    int unitsize = unit.size();
+    int unitsize = size();
     int elems = len(__join_cache);
     if(elems==1)
         return __join_cache->units[0];
@@ -56,7 +56,7 @@ template <class U> str *str::join(U *iter) {
         int k = 0;
         for(int m = 0; m<elems; m++) {
             str *t = __join_cache->units[m];
-            tsz = t->unit.size();
+            tsz = t->size();
             if (tsz == 1)
                 s->unit[k] = t->unit[0];
             else
@@ -66,7 +66,7 @@ template <class U> str *str::join(U *iter) {
                 if (unitsize==1)
                     s->unit[k] = unit[0];
                 else
-                    memcpy((void *)(s->unit.data()+k), unit.data(), unit.size());
+                    memcpy((void *)(s->unit.data()+k), unit.data(), size());
                 k += unitsize;
             }
         }

--- a/shedskin/lib/builtin/tuple.hpp
+++ b/shedskin/lib/builtin/tuple.hpp
@@ -46,7 +46,7 @@ template<class T> tuple2<T, T>::tuple2(tuple2<T, T> *p) {
 template<class T> tuple2<T, T>::tuple2(str *s) {
     this->__class__ = cl_tuple;
     this->units.resize(len(s));
-    int sz = s->unit.size();
+    int sz = s->size();
     for(int i=0; i<sz; i++)
         this->units[i] = __char_cache[((unsigned char)(s->unit[i]))];
 }

--- a/shedskin/lib/builtin/tuple.hpp
+++ b/shedskin/lib/builtin/tuple.hpp
@@ -74,13 +74,13 @@ template<class T> T tuple2<T, T>::__getitem__(__ss_int i) {
 template<class T> str *tuple2<T, T>::__repr__() {
     str *r = new str("(");
     for(int i = 0; i<this->__len__();i++) {
-        r->unit += repr(this->units[i])->unit;
+        *r += repr(this->units[i])->c_str();
         if(this->__len__() == 1 )
-            r->unit += ",";
+            *r += ",";
         if(i<this->__len__()-1)
-            r->unit += ", ";
+            *r += ", ";
     }
-    r->unit += ")";
+    *r += ")";
     return r;
 }
 

--- a/shedskin/lib/builtin/tuple.hpp
+++ b/shedskin/lib/builtin/tuple.hpp
@@ -245,7 +245,11 @@ template<class A, class B> long tuple2<A, B>::__hash__() {
 }
 
 template<class A, class B> str *tuple2<A, B>::__repr__() {
-    __GC_STRING s = "("+repr(first)->unit+", "+repr(second)->unit+")";
+    __GC_STRING s = "(";
+    s += repr(first)->c_str();
+    s += ", ";
+    s += repr(second)->c_str();
+    s += ")";
     return new str(s);
 }
 

--- a/shedskin/lib/cStringIO.cpp
+++ b/shedskin/lib/cStringIO.cpp
@@ -43,7 +43,7 @@ void *StringI::seek(__ss_int i, __ss_int w) {
 void *StringI::write(str *data) {
     __check_closed();
     if(data) {
-        const size_t size = data->unit.size();
+        const size_t size = data->size();
         s->unit.insert(pos, data->unit);
         pos += size;
         s->unit.erase(pos, size);

--- a/shedskin/lib/datetime.cpp
+++ b/shedskin/lib/datetime.cpp
@@ -417,10 +417,10 @@ datetime *datetime::combine(date *d, time *t) {
 datetime *datetime::strptime(str *date_string, str *format) {
 #ifdef WIN32
 	struct tm t = {0, 0, 0, 1, 0, 0, 0, 1, -1};
-    char *e = __time__::strptime(date_string->unit.c_str(), format->unit.c_str(), &t);
+    char *e = __time__::strptime(date_string->c_str(), format->c_str(), &t);
 #else
 	struct tm t = {0, 0, 0, 1, 0, 0, 0, 1, -1, 0, 0};
-    char *e = ::strptime(date_string->unit.c_str(), format->unit.c_str(), &t);
+    char *e = ::strptime(date_string->c_str(), format->c_str(), &t);
 #endif
     if(!e)
         throw new ValueError(new str("time data did not match format:  data="+date_string->unit+" fmt="+format->unit));

--- a/shedskin/lib/mmap.cpp
+++ b/shedskin/lib/mmap.cpp
@@ -627,7 +627,7 @@ __ss_int mmap::tell()
 void *mmap::write(str *string)
 {
     __raise_if_closed_or_not_writable();
-    size_t length = string->unit.size();
+    size_t length = string->size();
     if (m_position + length > m_end)
     {
         throw new ValueError(const_14);
@@ -641,7 +641,7 @@ void *mmap::write(str *string)
 void *mmap::write_byte(str *string)
 {
     __raise_if_closed_or_not_writable();
-    if (string == 0 or string->unit.size() != 1)
+    if (string == 0 or string->size() != 1)
     {
         throw new ValueError(const_8);
     }
@@ -656,7 +656,7 @@ void *mmap::write_byte(str *string)
 __ss_bool mmap::__contains__(str *string)
 {
     __raise_if_closed_or_not_readable();
-    if (string == 0 or string->unit.size() != 1)
+    if (string == 0 or string->size() != 1)
     {
         throw new ValueError(const_8);
     }
@@ -685,7 +685,7 @@ void *mmap::__setitem__(__ss_int index, str *character)
 {
     __raise_if_closed_or_not_writable();
     size_t id = __subscript(index);
-    if (character->unit.size() != 1)
+    if (character->size() != 1)
     {
         throw new IndexError(const_8);
     }

--- a/shedskin/lib/mmap.cpp
+++ b/shedskin/lib/mmap.cpp
@@ -239,7 +239,7 @@ void *mmap::__init__(int __ss_fileno_, __ss_int length_, str *tagname_, __ss_int
     DWORD dwErr = 0;
     HANDLE fh = 0;
     size_t size = 0;
-    const char *tagname = tagname_ ? tagname_->unit.c_str() : 0;
+    const char *tagname = tagname_ ? tagname_->c_str() : 0;
     switch (access_)
     {
     case ACCESS_READ:

--- a/shedskin/lib/os/__init__.cpp
+++ b/shedskin/lib/os/__init__.cpp
@@ -83,7 +83,7 @@ list<str *> *listdir(str *path) {
     DIR *dp;
     struct dirent *ep;
 
-    dp = opendir(path->unit.c_str());
+    dp = opendir(path->c_str());
     if (dp == 0)
         throw new OSError(path);
 
@@ -104,7 +104,7 @@ str *getcwd() {
 }
 
 void *chdir(str *dir) {
-    if(::chdir(dir->unit.c_str()) == -1)
+    if(::chdir(dir->c_str()) == -1)
         throw new OSError(dir);
     return NULL;
 }
@@ -114,24 +114,24 @@ str *strerror(__ss_int i) {
 }
 
 __ss_int system(str *c) {
-    return std::system(c->unit.c_str());
+    return std::system(c->c_str());
 }
 
 str *getenv(str *name, str *alternative) {
-    const char *waba = name->unit.c_str();
+    const char *waba = name->c_str();
     if(std::getenv(waba))
         return new str(std::getenv(waba));
     return alternative;
 }
 
 void *rename(str *a, str *b) {
-    if(std::rename(a->unit.c_str(), b->unit.c_str()) == -1)
+    if(std::rename(a->c_str(), b->c_str()) == -1)
         throw new OSError(a);
     return NULL;
 }
 
 void *remove(str *path) {
-    if(std::remove(path->unit.c_str()) == -1)
+    if(std::remove(path->c_str()) == -1)
         throw new OSError(path);
     return NULL;
 }
@@ -142,7 +142,7 @@ void *unlink(str *path) {
 }
 
 void *rmdir(str *a) {
-    if (::rmdir(a->unit.c_str()) == -1)
+    if (::rmdir(a->c_str()) == -1)
         throw new OSError(a);
     return NULL;
 }
@@ -177,9 +177,9 @@ void *removedirs(str *name) {
 
 void *mkdir(str *path, __ss_int mode) {
 #ifdef WIN32
-    if (::mkdir(path->unit.c_str()) == -1)
+    if (::mkdir(path->c_str()) == -1)
 #else
-    if (::mkdir(path->unit.c_str(), mode) == -1)
+    if (::mkdir(path->c_str(), mode) == -1)
 #endif
         throw new OSError(path);
     return NULL;
@@ -229,11 +229,11 @@ __cstat::__cstat(str *path, __ss_int t) {
     this->__class__ = cl___cstat;
 
     if(t==1) {
-        if(stat(path->unit.c_str(), &sbuf) == -1)
+        if(stat(path->c_str(), &sbuf) == -1)
             throw new OSError(path);
     } else if (t==2) {
 #ifndef WIN32
-        if(lstat(path->unit.c_str(), &sbuf) == -1)
+        if(lstat(path->c_str(), &sbuf) == -1)
 #endif
             throw new OSError(path);
     }
@@ -340,7 +340,7 @@ __ss_bool stat_float_times(__ss_int newvalue) {
 
 void *putenv(str* varname, str* value) {
     std::stringstream ss;
-    ss << varname->unit.c_str() << '=' << value->unit.c_str();
+    ss << varname->c_str() << '=' << value->c_str();
     ::putenv(const_cast<char*>(ss.str().c_str()));
     return NULL;
 }
@@ -354,14 +354,14 @@ __ss_int chmod (str* path, __ss_int val) {
 #ifdef WIN32
     DWORD attr;
     __ss_int res;
-    attr = GetFileAttributesA(var->unit.c_str());
+    attr = GetFileAttributesA(var->c_str());
 
     if (attr != 0xFFFFFFFF) {
         if (i & S_IWRITE)
             attr &= ~FILE_ATTRIBUTE_READONLY;
         else
             attr |= FILE_ATTRIBUTE_READONLY;
-        res = SetFileAttributesA(var->unit.c_str(), attr);
+        res = SetFileAttributesA(var->c_str(), attr);
     }
     else {
         res = 0;
@@ -371,7 +371,7 @@ __ss_int chmod (str* path, __ss_int val) {
     }
     return 0;
 #else
-    return ::chmod(path->unit.c_str(), val);
+    return ::chmod(path->c_str(), val);
 #endif
 }
 #endif
@@ -421,7 +421,7 @@ void *renames(str* old, str* _new) {
 popen_pipe::popen_pipe(str *cmd, str *flags) {
     if(flags == 0)
         flags = new str("r");
-    f = ::popen(cmd->unit.c_str(), flags->unit.c_str());
+    f = ::popen(cmd->c_str(), flags->c_str());
     if(f == 0)
         throw new IOError(cmd);
     name = cmd;
@@ -443,7 +443,7 @@ popen_pipe* popen(str* cmd, str* mode) {
 }
 
 popen_pipe* popen(str* cmd, str* mode, __ss_int) {
-    FILE* fp = ::popen(cmd->unit.c_str(), mode->unit.c_str());
+    FILE* fp = ::popen(cmd->c_str(), mode->c_str());
 
     if(!fp) throw new OSError(cmd);
     return new popen_pipe(fp);
@@ -471,7 +471,7 @@ void *fdatasync(__ss_int f1) {
 #endif
 
 __ss_int open(str *name, __ss_int flags) { /* XXX mode argument */
-    __ss_int fp = ::open(name->unit.c_str(), flags);
+    __ss_int fp = ::open(name->c_str(), flags);
     if(fp == -1)
         throw new OSError(new str("os.open failed"));
     return fp;
@@ -481,7 +481,7 @@ file* fdopen(__ss_int fd, str* mode, __ss_int) {
     if(!mode)
         mode = new str("r");
 /* XXX ValueError: mode string must begin with one of 'r', 'w', 'a' or 'U' */
-    FILE* fp = ::fdopen(fd, mode->unit.c_str());
+    FILE* fp = ::fdopen(fd, mode->c_str());
     if(fp == NULL)
         throw new OSError(new str("os.fdopen failed"));
 
@@ -507,7 +507,7 @@ str *read(__ss_int fd, __ss_int n) {  /* XXX slowness */
 
 __ss_int write(__ss_int fd, str *s) {
     __ss_int r;
-    if((r=::write(fd, s->unit.c_str(), len(s))) == -1)
+    if((r=::write(fd, s->c_str(), len(s))) == -1)
         throw new OSError(new str("os.write"));
     return r;
 }
@@ -538,7 +538,7 @@ time_t_to_FILE_TIME(time_t time_in, int nsec_in, FILETIME *out_ptr)
 
 void __utime_win32(str *path, FILETIME atime, FILETIME mtime) {
     HANDLE hFile;
-    const char *apath = path->unit.c_str();
+    const char *apath = path->c_str();
     hFile = CreateFileA(apath, FILE_WRITE_ATTRIBUTES, 0, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
        throw new OSError(new str("os.utime"));
@@ -572,12 +572,12 @@ void __utime(str *path, double actime, double modtime) {
     struct utimbuf buf;
     buf.actime = (time_t)actime;
     buf.modtime = (time_t)modtime;
-    if(::utime(path->unit.c_str(), &buf) == -1)
+    if(::utime(path->c_str(), &buf) == -1)
         throw new OSError(new str("os.utime"));
 }
 
 void __utime(str *path) {
-    if(::utime(path->unit.c_str(), NULL) == -1)
+    if(::utime(path->c_str(), NULL) == -1)
         throw new OSError(new str("os.utime"));
 }
 #endif
@@ -639,7 +639,7 @@ str *readlink(str *path) {
     while (1)
       {
         char *buffer = (char *) GC_malloc (size);
-	    __ss_int nchars = ::readlink(path->unit.c_str(), buffer, size);
+	    __ss_int nchars = ::readlink(path->c_str(), buffer, size);
     	if (nchars == -1) {
             throw new OSError(path);
   	    }
@@ -777,19 +777,19 @@ str *getlogin() {
 }
 
 void *chown(str *path, __ss_int uid, __ss_int gid) {
-    if (::chown(path->unit.c_str(), uid, gid) == -1)
+    if (::chown(path->c_str(), uid, gid) == -1)
         throw new OSError(path);
     return NULL;
 }
 
 void *lchown(str *path, __ss_int uid, __ss_int gid) {
-    if (::lchown(path->unit.c_str(), uid, gid) == -1)
+    if (::lchown(path->c_str(), uid, gid) == -1)
         throw new OSError(path);
     return NULL;
 }
 
 void *chroot(str *path) {
-    if (::chroot(path->unit.c_str()) == -1)
+    if (::chroot(path->c_str()) == -1)
         throw new OSError(path);
     return NULL;
 }
@@ -871,13 +871,13 @@ void *setpgrp() {
 }
 
 void *link(str *src, str *dst) {
-    if(::link(src->unit.c_str(), dst->unit.c_str()) == -1)
+    if(::link(src->c_str(), dst->c_str()) == -1)
         throw new OSError(new str("os.link"));
     return NULL;
 }
 
 void *symlink(str *src, str *dst) {
-    if(::symlink(src->unit.c_str(), dst->unit.c_str()) == -1)
+    if(::symlink(src->c_str(), dst->c_str()) == -1)
         throw new OSError(new str("os.symlink"));
     return NULL;
 }
@@ -888,7 +888,7 @@ __ss_int pathconf(str *path, str *name) {
     return pathconf(path, pathconf_names->__getitem__(name)); /* XXX errors */
 }
 __ss_int pathconf(str *path, __ss_int name) {
-    __ss_int limit = ::pathconf(path->unit.c_str(), name); /* XXX errors */
+    __ss_int limit = ::pathconf(path->c_str(), name); /* XXX errors */
     return limit;
 }
 
@@ -937,7 +937,7 @@ tuple2<double, double> *getloadavg() {
 }
 
 void *mkfifo(str *path, __ss_int mode) {
-    if(::mkfifo(path->unit.c_str(), mode) == -1)
+    if(::mkfifo(path->c_str(), mode) == -1)
         throw new OSError(new str("os.mkfifo"));
     return NULL;
 }
@@ -948,7 +948,7 @@ class_ *cl___vfsstat;
 
 __vfsstat::__vfsstat(str *path) {
     this->__class__ = cl___vfsstat;
-    if(statvfs(path->unit.c_str(), &vbuf) == -1)
+    if(statvfs(path->c_str(), &vbuf) == -1)
         throw new OSError(path);
     fill_er_up();
 }
@@ -1025,7 +1025,7 @@ str *urandom(__ss_int n) {
 }
 
 __ss_bool access(str *path, __ss_int mode) {
-    return __mbool(::access(path->unit.c_str(), mode) == 0);
+    return __mbool(::access(path->c_str(), mode) == 0);
 }
 
 tuple2<double, double> *times() {
@@ -1055,8 +1055,8 @@ file *tmpfile() {
     char *name;
     str *result;
     char *pfx = NULL;
-    if(prefix) pfx = (char *)(prefix->unit.c_str());
-    if((name = ::tempnam(dir->unit.c_str(), pfx)) == NULL)
+    if(prefix) pfx = (char *)(prefix->c_str());
+    if((name = ::tempnam(dir->c_str(), pfx)) == NULL)
         throw new OSError(new str("os.tempnam"));
     result = new str(name);
     free(name);
@@ -1074,7 +1074,7 @@ __ss_int __ss_minor(__ss_int dev) {
 }
 
 void *mknod(str *filename, __ss_int mode, __ss_int device) {
-    if(::mknod(filename->unit.c_str(), mode, device) == -1)
+    if(::mknod(filename->c_str(), mode, device) == -1)
         throw new OSError(new str("os.mknod"));
     return NULL;
 }
@@ -1082,7 +1082,7 @@ void *mknod(str *filename, __ss_int mode, __ss_int device) {
 char **__exec_argvlist(list<str *> *args) {
     char** argvlist = (char**)GC_malloc(sizeof(char*)*(args->__len__()+1));
     for(__ss_int i = 0; i < args->__len__(); ++i) {
-        argvlist[i] = (char *)(args->__getitem__(i)->unit.c_str());
+        argvlist[i] = (char *)(args->__getitem__(i)->c_str());
     }
     argvlist[args->__len__()] = NULL;
     return argvlist;
@@ -1092,7 +1092,7 @@ char **__exec_envplist(dict<str *, str *> *env) {
     char** envplist = (char**)GC_malloc(sizeof(char*)*(env->__len__()+1));
     list<tuple2<str *, str *> *> *items = env->items();
     for(__ss_int i=0; i < items->__len__(); i++) {
-        envplist[i] = (char *)(__add_strs(3, items->__getitem__(i)->__getfirst__(), new str("="), items->__getitem__(i)->__getsecond__())->unit.c_str());
+        envplist[i] = (char *)(__add_strs(3, items->__getitem__(i)->__getfirst__(), new str("="), items->__getitem__(i)->__getsecond__())->c_str());
     }
     envplist[items->__len__()] = NULL;
     return envplist;
@@ -1154,7 +1154,7 @@ void *execlpe(__ss_int n, str *file, ...) {
 }
 
 void *execv(str* file, list<str*>* args) {
-    ::execv(file->unit.c_str(), __exec_argvlist(args));
+    ::execv(file->c_str(), __exec_argvlist(args));
     throw new OSError(new str("os.execv"));
 }
 
@@ -1179,7 +1179,7 @@ void *execvp(str* file, list<str*>* args) {
 }
 
 void *execve(str* file, list<str*>* args, dict<str *, str *> *env) {
-    ::execve(file->unit.c_str(), __exec_argvlist(args), __exec_envplist(env));
+    ::execve(file->c_str(), __exec_argvlist(args), __exec_envplist(env));
     throw new OSError(new str("os.execve"));
 }
 
@@ -1299,7 +1299,7 @@ __ss_int getpid() {
 }
 
 void *unsetenv (str* var) {
-    ::unsetenv(var->unit.c_str());
+    ::unsetenv(var->c_str());
     return NULL;
 }
 

--- a/shedskin/lib/re.cpp
+++ b/shedskin/lib/re.cpp
@@ -489,7 +489,7 @@ match_object *re_object::__exec(str *subj, __ss_int pos, __ss_int endpos, __ss_i
     r = pcre_exec(
         compiled_pattern,
         study_info,
-        subj->unit.c_str(),
+        subj->c_str(),
         nendpos + 1,
         pos,
         flags,
@@ -570,7 +570,7 @@ re_object *compile(str *pat, __ss_int flags)
 
     //attempt a compilation
     cpat = pcre_compile(
-        pat->unit.c_str(),
+        pat->c_str(),
         options,
         (const char **)&errmsg,
         &erroff,

--- a/shedskin/lib/re.cpp
+++ b/shedskin/lib/re.cpp
@@ -448,7 +448,7 @@ match_object *match_iter::next(void)
 {
     match_object *mobj;
 
-    if((pos > endpos && endpos != -1) || (unsigned int)pos >= subj->unit.size()) throw new StopIteration();
+    if((pos > endpos && endpos != -1) || (unsigned int)pos >= subj->size()) throw new StopIteration();
 
     //get next match
     mobj = ro->__exec(subj, pos, endpos, flags);
@@ -463,7 +463,7 @@ match_object *match_iter::next(void)
 __iter<match_object *> *re_object::finditer(str *subj, __ss_int pos, __ss_int endpos, __ss_int flags)
 {
     if(endpos < pos && endpos != -1) throw new error(new str("end position less than initial"));
-    if((unsigned int)pos >= subj->unit.size()) throw new error(new str("starting position >= string length"));
+    if((unsigned int)pos >= subj->size()) throw new error(new str("starting position >= string length"));
 
     return new match_iter(this, subj, pos, endpos, flags);
 }
@@ -480,11 +480,11 @@ match_object *re_object::__exec(str *subj, __ss_int pos, __ss_int endpos, __ss_i
     captured = (int *)GC_MALLOC(clen * sizeof(int));
 
     //sanity checking
-    if(endpos == -1) nendpos = subj->unit.size() - 1;
+    if(endpos == -1) nendpos = subj->size() - 1;
     else if(endpos < pos) throw new error(new str("end position less than initial"));
     else nendpos = endpos;
 
-    if(subj->unit.size()!=0 and (unsigned int)pos >= subj->unit.size()) throw new error(new str("starting position >= string length"));
+    if(subj->size()!=0 and (unsigned int)pos >= subj->size()) throw new error(new str("starting position >= string length"));
 
     r = pcre_exec(
         compiled_pattern,

--- a/shedskin/lib/socket.cpp
+++ b/shedskin/lib/socket.cpp
@@ -163,9 +163,9 @@ file *socket::makefile(str *mode) {
 
 #ifdef WIN32
 	if (((fd = _open_osfhandle(_fd, O_BINARY)) < 0) ||
-	    ((fd = dup(fd)) < 0) || ((fp = fdopen(fd, mode->unit.c_str())) == NULL))
+	    ((fd = dup(fd)) < 0) || ((fp = fdopen(fd, mode->c_str())) == NULL))
 #else
-	if ((fd = dup(_fd)) < 0 || (fp = fdopen(fd, mode->unit.c_str())) == NULL)
+	if ((fd = dup(_fd)) < 0 || (fp = fdopen(fd, mode->c_str())) == NULL)
 #endif
 	{
 		/*if (fd >= 0)
@@ -219,7 +219,7 @@ static void tuple_to_sin_addr(sockaddr_in *dst, socket::inet_address src)
 {
     memset(dst, 0, sizeof(sockaddr_in));
     dst->sin_family = AF_INET;
-    const char *host = src->first->unit.c_str();
+    const char *host = src->first->c_str();
     dst->sin_addr.s_addr = string_to_addr(host);
     dst->sin_port = htons(src->second);
 }
@@ -244,7 +244,7 @@ socket *socket::setsockopt(__ss_int level, __ss_int optname, __ss_int value) {
 socket *socket::connect(socket::inet_address address) {
     if (family != AF_INET)
         throw new ValueError(invalid_address);
-    const char *host = address->first->unit.c_str();
+    const char *host = address->first->c_str();
     int port = address->second;
 
     sockaddr_in sin;
@@ -264,7 +264,7 @@ socket *socket::connect(pyseq<str *> *address)
     sockaddr_un smup;
     smup.sun_family = AF_UNIX;
     const str* __0 = address->__getitem__(0);
-    strcpy(smup.sun_path, __0->unit.c_str());
+    strcpy(smup.sun_path, __0->c_str());
 
     return connect(reinterpret_cast<sockaddr *>(&smup), sizeof(smup));
 }
@@ -420,7 +420,7 @@ __ss_int socket::send(str *string, __ss_int flags) {
 }
 
 __ss_int socket::sendall(str *string, __ss_int flags) {
-    const char *s = string->unit.c_str();
+    const char *s = string->c_str();
     size_t offset = 0;
     size_t len = string->__len__(); //FIXME is this guaranteed to be the same as the C string length, even if we are dealing with wide/unicode?
 
@@ -433,7 +433,7 @@ __ss_int socket::sendto(str* msg, __ss_int flags, socket::inet_address addr)
 {
     write_wait();
 
-    const char *buf = msg->unit.c_str();
+    const char *buf = msg->c_str();
     size_t buflen = strlen(buf);
 
     sockaddr *sa;
@@ -608,7 +608,7 @@ socket *socket::bind(pyseq<str *> *address)
     sockaddr_un smup;
     smup.sun_family = AF_UNIX;
     const str* __0 = address->__getitem__(0);
-    strcpy(smup.sun_path, __0->unit.c_str());
+    strcpy(smup.sun_path, __0->c_str());
 
     return bind(reinterpret_cast<sockaddr *>(&smup), sizeof(smup));
 }
@@ -714,7 +714,7 @@ void __exit()
 
 str *gethostbyname(str *hostname)
 {
-    hostent *he = ::gethostbyname(hostname->unit.c_str());
+    hostent *he = ::gethostbyname(hostname->c_str());
     if (!he)
         throw new herror(host_not_found);
     char ip[sizeof("xxx.xxx.xxx.xxx")];
@@ -725,13 +725,13 @@ str *gethostbyname(str *hostname)
 
 str *inet_aton(str *x)
 {
-    int addr = string_to_addr(x->unit.c_str());
+    int addr = string_to_addr(x->c_str());
     return new str((char *) &addr, 4);
 }
 
 str *inet_ntoa(str *x)
 {
-    const char *s = x->unit.c_str();
+    const char *s = x->c_str();
     int addr = *((int *) s);
     char ip[sizeof("xxx.xxx.xxx.xxx")];
     sprintf(ip, "%d.%d.%d.%d", ((addr >> 24) & 0xff), ((addr >> 16) & 0xff), ((addr >> 8) & 0xff), (addr & 0xff));

--- a/shedskin/lib/socket.cpp
+++ b/shedskin/lib/socket.cpp
@@ -416,7 +416,7 @@ int socket::send(const char *s, size_t len, int flags)
 }
 
 __ss_int socket::send(str *string, __ss_int flags) {
-    return send( string->unit.data(), string->unit.size(), flags );
+    return send( string->unit.data(), string->size(), flags );
 }
 
 __ss_int socket::sendall(str *string, __ss_int flags) {

--- a/shedskin/lib/time.cpp
+++ b/shedskin/lib/time.cpp
@@ -219,7 +219,7 @@ str *strftime(str *format, struct_time* tuple) {
     do {
         size *= 2;
         buf = new char[size];
-        n = ::strftime(buf, size, format->unit.c_str(), time_tuple);
+        n = ::strftime(buf, size, format->c_str(), time_tuple);
     } while(n == 0);
     return new str(buf);
 }
@@ -885,11 +885,11 @@ struct_time *strptime(str *string, str *format) {
 #ifdef WIN32
     tm time_tuple = {0, 0, 0, 1, 0, 0, 0, 1, -1};
     /* XXX check if newer MinGW supports this */
-    if(!strptime(string->unit.c_str(), format->unit.c_str(), &time_tuple))
+    if(!strptime(string->c_str(), format->c_str(), &time_tuple))
         throw  new ValueError(new str("time data did not match format:  data="+string->unit+" fmt="+format->unit));
 #else
     tm time_tuple = {0, 0, 0, 1, 0, 0, 0, 1, -1, 0, 0};
-    if(!::strptime(string->unit.c_str(), format->unit.c_str(), &time_tuple))
+    if(!::strptime(string->c_str(), format->c_str(), &time_tuple))
         throw  new ValueError(new str("time data did not match format:  data="+string->unit+" fmt="+format->unit));
 #endif
     return tm2tuple(&time_tuple);


### PR DESCRIPTION
This way one could finally multiple inherit from the string std class and a
smart pointer. At least we are independent of the interface pointing to the
implementation.