### PR TITLE
Added a new trick to the Tricks section

### DIFF
--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -566,6 +566,19 @@ Tricks
 
   class statistics: pass
   s = statistics(); s.nodes = 28; s.solutions = set()
+  
+  
+* The same is also valid for the following two code fragments. Only the second one is supported:
+
+::
+
+  n = 20
+  mask = [0]*n
+  
+  mask = []
+  for i in range(n):
+      mask.append(0)
+
 
 * The evaluation order of arguments to a function or print changes with translation to C++, so it's better not to depend on this:
 


### PR DESCRIPTION
I added a new trick that I have been struggling uppon.
Declaring a list by using
`n = 50
list = [0]*50`
is not supported.

The workaround is:
```
n = 50
list = []
for i in range(n):
    list.append(0)
```