### PR TITLE
shedskin: Add __main__.py to allow execute package with python's -m switch.

### DIFF
--- a/shedskin/__main__.py
+++ b/shedskin/__main__.py
@@ -1,0 +1,7 @@
+'''
+*** SHED SKIN Python-to-C++ Compiler ***
+Copyright 2005-2013 Mark Dufour; License GNU GPL version 3 (See LICENSE)
+
+'''
+from . import main
+main()


### PR DESCRIPTION
With this addition, it's possible to execute shedskin compiler without
using wrapper script:

python -m shedskin