### PR TITLE
Change command line interface to use argparse 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.?pp
 *.so
 *.vim
+*.egg-info
 FLAGS
 shedskin/FLAGS
 Makefile*
@@ -318,4 +319,5 @@ examples/sat
 examples/pygasus
 examples/tiger1.bmp
 examples2to3
+venv
 

--- a/shedskin/FLAGS.osx
+++ b/shedskin/FLAGS.osx
@@ -1,3 +1,3 @@
 CC=g++
 CCFLAGS=-O2 -std=c++17 -Wno-deprecated $(CPPFLAGS)
-LFLAGS=-lgc -lpcre $(LDFLAGS)
+LFLAGS=-lgc -lgccpp -liconv -lpcre $(LDFLAGS)

--- a/shedskin/infer.py
+++ b/shedskin/infer.py
@@ -957,7 +957,10 @@ def ifa_class_types(gx, cl, vars):
                 attr_types.append(frozenset())
         attr_types = tuple(attr_types)
         if all(attr_types):
-            ifa_logger.debug('IFA %s: %s %s', dcpa, zip([var.name for var in vars], map(list, attr_types)))
+            # print(dcpa, str(list(zip([var.name for var in vars], map(list, attr_types)))))
+            ifa_logger.debug('IFA %s: %s', dcpa, str(list(zip([var.name for var in vars], map(list, attr_types)))))
+        # if all(attr_types):
+        #     ifa_logger.debug('IFA %s: %s %s', dcpa, zip([var.name for var in vars], map(list, attr_types)))
         nr_classes[dcpa] = attr_types
         classes_nr[attr_types] = dcpa
     return classes_nr, nr_classes
@@ -1067,8 +1070,8 @@ def update_progressbar(gx, perc):
         )
         gx.progressbar.start()
 
-    with gx.terminal.location(x=0):
-        gx.progressbar.update(perc)
+    # with gx.terminal.location(x=0):
+    #     gx.progressbar.update(perc)
     if perc == 1:
         # Finished, so add a new line.
         sys.stdout.write('\n')

--- a/shedskin/lib/builtin.cpp
+++ b/shedskin/lib/builtin.cpp
@@ -228,8 +228,10 @@ void __ss_exit(int code) {
 #ifdef __SS_LONG
 template<> PyObject *__to_py(__ss_int i) { return PyLong_FromLongLong(i); }
 #endif
-template<> PyObject *__to_py(int i) { return PyInt_FromLong(i); }
-template<> PyObject *__to_py(long i) { return PyInt_FromLong(i); }
+// template<> PyObject *__to_py(int i) { return PyInt_FromLong(i); }
+template<> PyObject *__to_py(int i) { return PyLong_FromLong(i); }
+// template<> PyObject *__to_py(long i) { return PyInt_FromLong(i); }
+template<> PyObject *__to_py(long i) { return PyLong_FromLong(i); }
 template<> PyObject *__to_py(__ss_bool i) { return PyBool_FromLong(i.value); }
 template<> PyObject *__to_py(double d) { return PyFloat_FromDouble(d); }
 template<> PyObject *__to_py(void *v) { Py_INCREF(Py_None); return Py_None; }
@@ -237,13 +239,15 @@ template<> PyObject *__to_py(void *v) { Py_INCREF(Py_None); return Py_None; }
 void throw_exception() {
     PyObject *ptype, *pvalue, *ptraceback;
     PyErr_Fetch(&ptype, &pvalue, &ptraceback);
-    char *pStrErrorMessage = PyString_AsString(pvalue);
+    // char *pStrErrorMessage = PyString_AsString(pvalue);
+    char *pStrErrorMessage = PyBytes_AS_STRING(pvalue);
     throw new TypeError(new str(pStrErrorMessage));
 }
 
 #ifdef __SS_LONG
 template<> __ss_int __to_ss(PyObject *p) {
-    if(PyLong_Check(p) || PyInt_Check(p)) {
+    // if(PyLong_Check(p) || PyInt_Check(p)) {
+    if(PyLong_Check(p)) {
         __ss_int result = PyLong_AsLongLong(p);
         if (result == -1 && PyErr_Occurred() != NULL) {
             throw_exception();
@@ -255,8 +259,10 @@ template<> __ss_int __to_ss(PyObject *p) {
 #endif
 
 template<> int __to_ss(PyObject *p) {
-    if(PyLong_Check(p) || PyInt_Check(p)) {
-        int result = PyInt_AsLong(p);
+    // if(PyLong_Check(p) || PyInt_Check(p)) {
+    if(PyLong_Check(p)) {
+        // int result = PyInt_AsLong(p);
+        int result = PyLong_AsLong(p);
         if (result == -1 && PyErr_Occurred() != NULL) {
             throw_exception();
         }
@@ -272,7 +278,8 @@ template<> __ss_bool __to_ss(PyObject *p) {
 }
 
 template<> double __to_ss(PyObject *p) {
-    if(!PyInt_Check(p) and !PyFloat_Check(p))
+    // if(!PyInt_Check(p) and !PyFloat_Check(p))
+    if(!PyLong_AsLong(p) and !PyFloat_Check(p))
         throw new TypeError(new str("error in conversion to Shed Skin (float or int expected)"));
     return PyFloat_AsDouble(p);
 }

--- a/shedskin/lib/builtin.cpp
+++ b/shedskin/lib/builtin.cpp
@@ -279,7 +279,7 @@ template<> __ss_bool __to_ss(PyObject *p) {
 
 template<> double __to_ss(PyObject *p) {
     // if(!PyInt_Check(p) and !PyFloat_Check(p))
-    if(!PyLong_AsLong(p) and !PyFloat_Check(p))
+    if(!PyLong_Check(p) and !PyFloat_Check(p))
         throw new TypeError(new str("error in conversion to Shed Skin (float or int expected)"));
     return PyFloat_AsDouble(p);
 }

--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -735,15 +735,19 @@ str *str::capitalize() {
 
 #ifdef __SS_BIND
 str::str(PyObject *p) : hash(-1) {
-    if(!PyString_Check(p))
+    if(!PyBytes_Check(p))
+    // if(!PyUnicode_Check(p))
+    // if(!PyString_Check(p))
         throw new TypeError(new str("error in conversion to Shed Skin (string expected)"));
 
     __class__ = cl_str_;
-    unit = __GC_STRING(PyString_AsString(p), PyString_Size(p));
+    // unit = __GC_STRING(PyString_AsString(p), PyString_Size(p));
+    unit = __GC_STRING(PyBytes_AS_STRING(p), PyBytes_Size(p));
 }
 
 PyObject *str::__to_py__() {
-    return PyString_FromStringAndSize(c_str(), size());
+    // return PyString_FromStringAndSize(c_str(), size());
+    return PyBytes_FromStringAndSize(c_str(), size());
 }
 #endif
 

--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -735,19 +735,21 @@ str *str::capitalize() {
 
 #ifdef __SS_BIND
 str::str(PyObject *p) : hash(-1) {
-    if(!PyBytes_Check(p))
-    // if(!PyUnicode_Check(p))
+    // if(!PyBytes_Check(p))
+    if(!PyUnicode_Check(p))
     // if(!PyString_Check(p))
         throw new TypeError(new str("error in conversion to Shed Skin (string expected)"));
 
     __class__ = cl_str_;
+    unit = __GC_STRING(PyUnicode_AsUTF8(p), PyUnicode_GET_SIZE(p));
     // unit = __GC_STRING(PyString_AsString(p), PyString_Size(p));
-    unit = __GC_STRING(PyBytes_AS_STRING(p), PyBytes_Size(p));
+    // unit = __GC_STRING(PyBytes_AS_STRING(p), PyBytes_Size(p));
 }
 
 PyObject *str::__to_py__() {
     // return PyString_FromStringAndSize(c_str(), size());
-    return PyBytes_FromStringAndSize(c_str(), size());
+    // return PyBytes_FromStringAndSize(c_str(), size());
+    return PyUnicode_FromStringAndSize(c_str(), size());
 }
 #endif
 


### PR DESCRIPTION
This should be non-controversial. I've changed the old `optparse` based cli in `shedskin/__init__.py` to use `argparse`. This should be more scalable going forward. It's a small change and mirrors exactly what `optparse` used to do. Of course the `argparse` module is a stdlib module only available in python3 

