### PR TITLE
Frontend class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.?pp
 *.so
 *.vim
+*.egg-info
 FLAGS
 shedskin/FLAGS
 Makefile*
@@ -318,4 +319,5 @@ examples/sat
 examples/pygasus
 examples/tiger1.bmp
 examples2to3
+venv
 

--- a/scripts/shedskin
+++ b/scripts/shedskin
@@ -1,3 +1,3 @@
-#!/usr/bin/env python
-import shedskin
-shedskin.main()
+#!/usr/bin/env python3
+from shedskin import Shedskin
+Shedskin.commandline()

--- a/shedskin/FLAGS.osx
+++ b/shedskin/FLAGS.osx
@@ -1,3 +1,3 @@
 CC=g++
 CCFLAGS=-O2 -std=c++17 -Wno-deprecated $(CPPFLAGS)
-LFLAGS=-lgc -lpcre $(LDFLAGS)
+LFLAGS=-lgc -lgccpp -liconv -lpcre $(LDFLAGS)

--- a/shedskin/__init__.py
+++ b/shedskin/__init__.py
@@ -1,8 +1,8 @@
-'''
+"""
 *** SHED SKIN Python-to-C++ Compiler ***
 Copyright 2005-2022 Mark Dufour and contributors; License GNU GPL version 3 (See LICENSE)
 
-'''
+"""
 
 import argparse
 import logging
@@ -30,12 +30,13 @@ class ShedskinFormatter(logging.Formatter):
 
     def __init__(self, gx, datefmt=None):
         self.gx = gx
-        move = gx.terminal.move_x(0)
+        move = self.gx.terminal.move_x(0)
         self._info_formatter = logging.Formatter(
             move + '%(message)s', datefmt=datefmt)
         self._other_formatter = logging.Formatter(
-            move + gx.terminal.bold('*%(levelname)s*') + ' %(message)s',
-            datefmt=datefmt)
+            move + self.gx.terminal.bold(
+                '*%(levelname)s*') + ' %(message)s', datefmt=datefmt
+        )
 
     def format(self, record):
         if record.levelname == 'INFO':
@@ -43,158 +44,171 @@ class ShedskinFormatter(logging.Formatter):
         return self._other_formatter.format(record)
 
 
-def parse_command_line_options():
-    gx = GlobalInfo()
-    gx.terminal = blessings.Terminal()
+class Shedskin:
+    """Main shedksin frontend class
+    """
+    def __init__(self, module_name):
+        self.module_name = self.get_name(module_name)
+        self.gx = GlobalInfo()
+        self.gx.terminal = blessings.Terminal()
 
-    # --- command-line options
-    parser = argparse.ArgumentParser(
-        prog = 'shedskin',
-        usage='%(prog)s [options] <name>',
-        description = 'Python-to-C++ Compiler',
-        epilog = 'Text at the bottom of help')
+        # silent -> WARNING only, debug -> DEBUG, default -> INFO
+        console = logging.StreamHandler(stream=sys.stdout)
+        console.setFormatter(ShedskinFormatter(self.gx))
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.log.addHandler(console)
+        self.log.setLevel(logging.INFO)
+        # debug=3 -> IFA (iterative flow analysis) logging enabled.
+        self.ifa_log = logging.getLogger('infer.ifa')
+        self.ifa_log.addHandler(console)
+        self.ifa_log.setLevel(logging.INFO)
 
-    arg = opt = parser.add_argument
-
-    arg("name", help="Python file or module to compile")
-
-    opt("-a", "--ann",       help="Output annotated source code (.ss.py)", action="store_true")
-    opt("-b", "--nobounds",  help="Disable bounds checking", action="store_true")
-    opt("-c", "--nogc",      help="Disable garbage collection", action="store_true")
-    opt("-d", "--debug",     help="Set debug level", type=int)
-    opt("-e", "--extmod",    help="Generate extension module", action="store_true")
-    opt("-f", "--flags",     help="Provide alternate Makefile flags")
-    opt("-g", "--nogcwarns", help="Disable runtime GC warnings", action="store_true")
-    opt("-l", "--long",      help="Use long long '64-bit' integers", action="store_true")
-    opt("-m", "--makefile",  help="Specify alternate Makefile name")
-    opt("-n", "--silent",    help="Silent mode, only show warnings", action="store_true")
-    opt("-o", "--noassert",  help="Disable assert statements", action="store_true")
-    opt("-r", "--random",    help="Use fast random number generator (rand())", action="store_true")
-    opt("-w", "--nowrap",    help="Disable wrap-around checking", action="store_true")
-    opt("-x", "--traceback", help="Print traceback for uncaught exceptions", action="store_true")
-    opt("-L", "--lib",       help="Add a library directory", nargs='*')
-
-    # opt("--pypy",        "-p", help="Make extension module PyPy-compatible")
-    # opt("--msvc",        "-v", help="Output MSVC-style Makefile")
-
-    args = parser.parse_args()
-
-    logging_level = logging.INFO
-    ifa_logging_level = logging.INFO
-
-    if args.nobounds:
-        gx.bounds_checking = False
-
-    if args.extmod:
-        gx.extension_module = True
-
-    if args.ann:
-        gx.annotation = True
-
-    if args.debug:
-        logging_level = logging.DEBUG
-        if args.debug == 3:
-            ifa_logging_level = logging.DEBUG
+    def get_name(self, module_name):
+        """Normalizes the module_name to be parsed
         
-    if args.long:
-        gx.longlong = True
-        
-    if args.nogc:
-        gx.nogc = True
-        
-    if args.nogcwarns:
-        gx.gcwarns = False
-        
-    if args.nowrap:
-        gx.wrap_around_check = False
-
-    if args.random:
-        gx.fast_random = True
-                
-    if args.noassert:
-        gx.assertions = False
-        
-    # if args.pypy:
-    #     gx.pypy = True
-        
-    if args.makefile:
-        gx.makefile_name = args.makefile
-        
-    if args.silent:
-        logging_level = logging.WARNING
-
-    # if args.msvc:
-    #     gx.msvc = True
-        
-    if args.traceback:
-        gx.traceback = True
-        
-    # [str]
-    if args.lib:
-        gx.libdirs = args.lib + gx.libdirs
-        
-    if args.flags:
-        if not os.path.isfile(args.flags):
-            logging.error("no such file: '%s'", args.flags)
+        :param      module_name:     The module name
+        :type       module_name:     str
+        """
+        name = module_name[:]
+        if not name.endswith('.py'):
+            name += '.py'
+        if not os.path.isfile(name):
+            self.log.error("no such file: '%s'", name)
             sys.exit(1)
-        gx.flags = args.flags
+        return os.path.splitext(name)[0]
 
-    # silent -> WARNING only, debug -> DEBUG, default -> INFO
-    console = logging.StreamHandler(stream=sys.stdout)
-    console.setFormatter(ShedskinFormatter(gx))
-    root = logging.getLogger('')
-    root.addHandler(console)
-    root.setLevel(logging_level)
-    # debug=3 -> IFA (iterative flow analysis) logging enabled.
-    logging.getLogger('infer.ifa').setLevel(ifa_logging_level)
-
-    logging.info('*** SHED SKIN Python-to-C++ Compiler 0.9.5 *** - ')
-    logging.info('Copyright 2005-2022 Mark Dufour and contributors; License GNU GPL version 3 (See LICENSE)')
-    logging.info('')
-
-    # --- some checks
-    major, minor = sys.version_info[:2]
-    if (major, minor) not in [(2, 7), (3, 8), (3, 9), (3, 10), (3, 11)]:
-        logging.error('Shed Skin is not compatible with this version of Python')
-        sys.exit(1)
-    if sys.platform == 'win32' and os.path.isdir('c:/mingw'):
-        logging.error('please rename or remove c:/mingw, as it conflicts with Shed Skin')
-        sys.exit()
-    if sys.platform == 'win32' and struct.calcsize('P') == 8 and gx.extension_module:
-        logging.warning('64-bit python may not come with necessary file to build extension module')
-
-    # --- argument
-    name = args.name[:]
-    if not name.endswith('.py'):
-        name += '.py'
-    if not os.path.isfile(name):
-        logging.error("no such file: '%s'", name)
-        sys.exit(1)
-    main_module_name = os.path.splitext(name)[0]
+    def start(self):
+        """start and sequence main shedksin processes
+        """
+        # --- analyze & annotate
+        t0 = time.time()
+        analyze(self.gx, self.module_name)
+        annotate(self.gx)
+        generate_code(self.gx)
+        print_errors()
+        self.log.info('[elapsed time: %.2f seconds]', (time.time() - t0))
 
 
-    return gx, main_module_name
+    @classmethod
+    def commandline(cls):
+        """command line api
+        """
 
+        sys.setrecursionlimit(100000)
 
-def start(gx, main_module_name):
-    # --- analyze & annotate
-    t0 = time.time()
-    analyze(gx, main_module_name)
-    annotate(gx)
-    generate_code(gx)
-    print_errors()
-    logging.info('[elapsed time: %.2f seconds]', (time.time() - t0))
+        # --- command-line options
+        parser = argparse.ArgumentParser(
+            prog = 'shedskin',
+            usage='%(prog)s [options] <name>',
+            description = 'Python-to-C++ Compiler',
+            epilog = 'Text at the bottom of help')
 
+        arg = opt = parser.add_argument
 
-def main():
-    sys.setrecursionlimit(100000)
-    gx, main_module_name = parse_command_line_options()
-    try:
-        start(gx, main_module_name)
-    except KeyboardInterrupt as e:
-        logging.debug('KeyboardInterrupt', exc_info=True)
-        sys.exit(1)
+        arg("name", help="Python file or module to compile")
+
+        opt("-a", "--ann",       help="Output annotated source code (.ss.py)", action="store_true")
+        opt("-b", "--nobounds",  help="Disable bounds checking", action="store_true")
+        opt("-c", "--nogc",      help="Disable garbage collection", action="store_true")
+        opt("-d", "--debug",     help="Set debug level", type=int)
+        opt("-e", "--extmod",    help="Generate extension module", action="store_true")
+        opt("-f", "--flags",     help="Provide alternate Makefile flags")
+        opt("-g", "--nogcwarns", help="Disable runtime GC warnings", action="store_true")
+        opt("-l", "--long",      help="Use long long '64-bit' integers", action="store_true")
+        opt("-m", "--makefile",  help="Specify alternate Makefile name")
+        opt("-n", "--silent",    help="Silent mode, only show warnings", action="store_true")
+        opt("-o", "--noassert",  help="Disable assert statements", action="store_true")
+        opt("-r", "--random",    help="Use fast random number generator (rand())", action="store_true")
+        opt("-w", "--nowrap",    help="Disable wrap-around checking", action="store_true")
+        opt("-x", "--traceback", help="Print traceback for uncaught exceptions", action="store_true")
+        opt("-L", "--lib",       help="Add a library directory", nargs='*')
+
+        # opt("--pypy",        "-p", help="Make extension module PyPy-compatible")
+        # opt("--msvc",        "-v", help="Output MSVC-style Makefile")
+
+        args = parser.parse_args()
+
+        ss = shedskin = cls(args.name)
+
+        ss.log.info('*** SHED SKIN Python-to-C++ Compiler 0.9.5 *** - ')
+        ss.log.info('Copyright 2005-2022 Mark Dufour and contributors; License GNU GPL version 3 (See LICENSE)')
+        ss.log.info('')        
+
+        if args.nobounds:
+            ss.gx.bounds_checking = False
+
+        if args.extmod:
+            ss.gx.extension_module = True
+
+        if args.ann:
+            ss.gx.annotation = True
+
+        if args.debug:
+            ss.log.setLevel(logging.DEBUG)
+            if args.debug == 3:
+                ss.ifa_log.setLevel(logging.DEBUG)
+            
+        if args.long:
+            ss.gx.longlong = True
+            
+        if args.nogc:
+            ss.gx.nogc = True
+            
+        if args.nogcwarns:
+            ss.gx.gcwarns = False
+            
+        if args.nowrap:
+            ss.gx.wrap_around_check = False
+
+        if args.random:
+            ss.gx.fast_random = True
+                    
+        if args.noassert:
+            ss.gx.assertions = False
+            
+        # if args.pypy:
+        #     ss.gx.pypy = True
+            
+        if args.makefile:
+            ss.gx.makefile_name = args.makefile
+            
+        if args.silent:
+            ss.log.setLevel(logging.WARNING)
+
+        # if args.msvc:
+        #     ss.gx.msvc = True
+            
+        if args.traceback:
+            ss.gx.traceback = True
+            
+        # [str]
+        if args.lib:
+            ss.gx.libdirs = args.lib + ss.gx.libdirs
+        
+        # str
+        if args.flags:
+            if not os.path.isfile(args.flags):
+                ss.log.error("no such file: '%s'", args.flags)
+                sys.exit(1)
+            ss.gx.flags = args.flags
+
+        # --- some checks
+        major, minor = sys.version_info[:2]
+        if (major, minor) not in [(2, 7), (3, 8), (3, 9), (3, 10), (3, 11)]:
+            ss.log.error('Shed Skin is not compatible with this version of Python')
+            sys.exit(1)
+        if sys.platform == 'win32' and os.path.isdir('c:/mingw'):
+            ss.log.error('please rename or remove c:/mingw, as it conflicts with Shed Skin')
+            sys.exit()
+        if sys.platform == 'win32' and struct.calcsize('P') == 8 and ss.gx.extension_module:
+            ss.log.warning('64-bit python may not come with necessary file to build extension module')
+        
+        try:
+            ss.start()
+        except KeyboardInterrupt as e:
+            ss.log.debug('KeyboardInterrupt', exc_info=True)
+            sys.exit(1)
 
 
 if __name__ == '__main__':
-    main()
+    Shedskin.commandline()

--- a/shedskin/__main__.py
+++ b/shedskin/__main__.py
@@ -1,7 +1,7 @@
-'''
+"""
 *** SHED SKIN Python-to-C++ Compiler ***
 Copyright 2005-2013 Mark Dufour; License GNU GPL version 3 (See LICENSE)
 
-'''
-from . import main
-main()
+"""
+from . import Shedskin
+Shedskin.commandline()

--- a/shedskin/infer.py
+++ b/shedskin/infer.py
@@ -957,7 +957,10 @@ def ifa_class_types(gx, cl, vars):
                 attr_types.append(frozenset())
         attr_types = tuple(attr_types)
         if all(attr_types):
-            ifa_logger.debug('IFA %s: %s %s', dcpa, zip([var.name for var in vars], map(list, attr_types)))
+            # print(dcpa, str(list(zip([var.name for var in vars], map(list, attr_types)))))
+            ifa_logger.debug('IFA %s: %s', dcpa, str(list(zip([var.name for var in vars], map(list, attr_types)))))
+        # if all(attr_types):
+        #     ifa_logger.debug('IFA %s: %s %s', dcpa, zip([var.name for var in vars], map(list, attr_types)))
         nr_classes[dcpa] = attr_types
         classes_nr[attr_types] = dcpa
     return classes_nr, nr_classes
@@ -1067,8 +1070,8 @@ def update_progressbar(gx, perc):
         )
         gx.progressbar.start()
 
-    with gx.terminal.location(x=0):
-        gx.progressbar.update(perc)
+    # with gx.terminal.location(x=0):
+    #     gx.progressbar.update(perc)
     if perc == 1:
         # Finished, so add a new line.
         sys.stdout.write('\n')

--- a/shedskin/lib/builtin.cpp
+++ b/shedskin/lib/builtin.cpp
@@ -228,8 +228,10 @@ void __ss_exit(int code) {
 #ifdef __SS_LONG
 template<> PyObject *__to_py(__ss_int i) { return PyLong_FromLongLong(i); }
 #endif
-template<> PyObject *__to_py(int i) { return PyInt_FromLong(i); }
-template<> PyObject *__to_py(long i) { return PyInt_FromLong(i); }
+// template<> PyObject *__to_py(int i) { return PyInt_FromLong(i); }
+template<> PyObject *__to_py(int i) { return PyLong_FromLong(i); }
+// template<> PyObject *__to_py(long i) { return PyInt_FromLong(i); }
+template<> PyObject *__to_py(long i) { return PyLong_FromLong(i); }
 template<> PyObject *__to_py(__ss_bool i) { return PyBool_FromLong(i.value); }
 template<> PyObject *__to_py(double d) { return PyFloat_FromDouble(d); }
 template<> PyObject *__to_py(void *v) { Py_INCREF(Py_None); return Py_None; }
@@ -237,13 +239,15 @@ template<> PyObject *__to_py(void *v) { Py_INCREF(Py_None); return Py_None; }
 void throw_exception() {
     PyObject *ptype, *pvalue, *ptraceback;
     PyErr_Fetch(&ptype, &pvalue, &ptraceback);
-    char *pStrErrorMessage = PyString_AsString(pvalue);
+    // char *pStrErrorMessage = PyString_AsString(pvalue);
+    char *pStrErrorMessage = PyBytes_AS_STRING(pvalue);
     throw new TypeError(new str(pStrErrorMessage));
 }
 
 #ifdef __SS_LONG
 template<> __ss_int __to_ss(PyObject *p) {
-    if(PyLong_Check(p) || PyInt_Check(p)) {
+    // if(PyLong_Check(p) || PyInt_Check(p)) {
+    if(PyLong_Check(p)) {
         __ss_int result = PyLong_AsLongLong(p);
         if (result == -1 && PyErr_Occurred() != NULL) {
             throw_exception();
@@ -255,8 +259,10 @@ template<> __ss_int __to_ss(PyObject *p) {
 #endif
 
 template<> int __to_ss(PyObject *p) {
-    if(PyLong_Check(p) || PyInt_Check(p)) {
-        int result = PyInt_AsLong(p);
+    // if(PyLong_Check(p) || PyInt_Check(p)) {
+    if(PyLong_Check(p)) {
+        // int result = PyInt_AsLong(p);
+        int result = PyLong_AsLong(p);
         if (result == -1 && PyErr_Occurred() != NULL) {
             throw_exception();
         }
@@ -272,7 +278,8 @@ template<> __ss_bool __to_ss(PyObject *p) {
 }
 
 template<> double __to_ss(PyObject *p) {
-    if(!PyInt_Check(p) and !PyFloat_Check(p))
+    // if(!PyInt_Check(p) and !PyFloat_Check(p))
+    if(!PyLong_AsLong(p) and !PyFloat_Check(p))
         throw new TypeError(new str("error in conversion to Shed Skin (float or int expected)"));
     return PyFloat_AsDouble(p);
 }

--- a/shedskin/lib/builtin.cpp
+++ b/shedskin/lib/builtin.cpp
@@ -279,7 +279,7 @@ template<> __ss_bool __to_ss(PyObject *p) {
 
 template<> double __to_ss(PyObject *p) {
     // if(!PyInt_Check(p) and !PyFloat_Check(p))
-    if(!PyLong_AsLong(p) and !PyFloat_Check(p))
+    if(!PyLong_Check(p) and !PyFloat_Check(p))
         throw new TypeError(new str("error in conversion to Shed Skin (float or int expected)"));
     return PyFloat_AsDouble(p);
 }

--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -735,15 +735,19 @@ str *str::capitalize() {
 
 #ifdef __SS_BIND
 str::str(PyObject *p) : hash(-1) {
-    if(!PyString_Check(p))
+    if(!PyBytes_Check(p))
+    // if(!PyUnicode_Check(p))
+    // if(!PyString_Check(p))
         throw new TypeError(new str("error in conversion to Shed Skin (string expected)"));
 
     __class__ = cl_str_;
-    unit = __GC_STRING(PyString_AsString(p), PyString_Size(p));
+    // unit = __GC_STRING(PyString_AsString(p), PyString_Size(p));
+    unit = __GC_STRING(PyBytes_AS_STRING(p), PyBytes_Size(p));
 }
 
 PyObject *str::__to_py__() {
-    return PyString_FromStringAndSize(c_str(), size());
+    // return PyString_FromStringAndSize(c_str(), size());
+    return PyBytes_FromStringAndSize(c_str(), size());
 }
 #endif
 

--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -735,19 +735,21 @@ str *str::capitalize() {
 
 #ifdef __SS_BIND
 str::str(PyObject *p) : hash(-1) {
-    if(!PyBytes_Check(p))
-    // if(!PyUnicode_Check(p))
+    // if(!PyBytes_Check(p))
+    if(!PyUnicode_Check(p))
     // if(!PyString_Check(p))
         throw new TypeError(new str("error in conversion to Shed Skin (string expected)"));
 
     __class__ = cl_str_;
+    unit = __GC_STRING(PyUnicode_AsUTF8(p), PyUnicode_GET_SIZE(p));
     // unit = __GC_STRING(PyString_AsString(p), PyString_Size(p));
-    unit = __GC_STRING(PyBytes_AS_STRING(p), PyBytes_Size(p));
+    // unit = __GC_STRING(PyBytes_AS_STRING(p), PyBytes_Size(p));
 }
 
 PyObject *str::__to_py__() {
     // return PyString_FromStringAndSize(c_str(), size());
-    return PyBytes_FromStringAndSize(c_str(), size());
+    // return PyBytes_FromStringAndSize(c_str(), size());
+    return PyUnicode_FromStringAndSize(c_str(), size());
 }
 #endif
 


### PR DESCRIPTION
This is another non-controversial change to create a frontend `Shedskin` class. It has only the `module_name` as a param, but it can further grow to include all the shedksin params such it can be used programmatically instead of only through the command line.

