### PR TITLE
initial fix for global variables issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@
 *.txt
 *.ini
 *.csv
-tests/*.?pp
+tests/**/*.?pp
 *.so
+*.so.dSYM
 *.vim
 *.egg-info
 FLAGS

--- a/shedskin/extmod.py
+++ b/shedskin/extmod.py
@@ -23,7 +23,7 @@ def clname(cl):
     """class name normalizer
 
     :param      cl:   class object
-    :type       cl:   shedskin.python.Class
+    :type       cl:   python.Class
 
     :returns:   class name with shedksin prefix and module qualifier
     :rtype:     str
@@ -67,8 +67,7 @@ class ExtensionModule:
                 )
 
     def supported_vars(self, variables):  # XXX virtuals?
-        """
-        { item_description }
+        """XXX currently only classs / instance variables
         """
         supported = []
         for var in variables:
@@ -199,6 +198,7 @@ class ExtensionModule:
         :returns:   { description_of_the_return_value }
         :rtype:     { return_type_description }
         """
+
         # global variables
         for var in self.supported_vars(self.gv.mv.globals.values()):
             if [
@@ -596,11 +596,17 @@ class ExtensionModule:
             write("    if (PyType_Ready(&%sObjectType) < 0)" % clname(cl))
             write("        return NULL;\n")
 
+        write("    // create extension module")
         __ss_mod = "_".join(self.gv.module.name_list)
         write("    __ss_mod_%s = m = PyModule_Create(&%smodule);" % (__ss_mod, __ss_mod))
         write("    if (m == NULL)")
         write("        return NULL;\n")
 
+        write("    // add global variables")
+        self.do_add_globals(classes, 'm')
+        write("")
+
+        write("    // add type objects")
         for cl in classes:
             write("    Py_INCREF(&%sObjectType);" % clname(cl))
             write('    if (PyModule_AddObject(m, "%s", (PyObject *) &%sObjectType) < 0) {' % (cl.ident, clname(cl)))

--- a/shedskin/makefile.py
+++ b/shedskin/makefile.py
@@ -225,7 +225,10 @@ def generate_makefile(gx):
     if not gx.extension_module:
         if not gx.msvc:
             targets += [ident + '_prof' + ext, ident + '_debug' + ext]
-    write('\trm -f %s\n' % ' '.join(targets))
+    write('\trm -f %s' % ' '.join(targets))
+    if sys.platform == 'darwin':
+        write('\trm -rf %s.dSYM\n' % ' '.join(targets))
+    write()
 
     # phony
     phony = '.PHONY: all clean'

--- a/shedskin/makefile.py
+++ b/shedskin/makefile.py
@@ -190,7 +190,6 @@ def generate_makefile(gx):
         write()
         write('STATIC_LIBS=$(GC_STATIC) $(GCCPP_STATIC) $(PCRE_STATIC)')
         write('STATIC_CCFLAGS=$(CCFLAGS) -I$(GC_INCLUDE) -I$(PCRE_INCLUDE)')
-        # write('STATIC_LFLAGS=$(LDFLAGS) -L/usr/local/lib -bundle -undefined dynamic_lookup -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic')
         write('STATIC_LFLAGS=' + MATCH.group(2))
         write()
 
@@ -212,10 +211,10 @@ def generate_makefile(gx):
         write(ident + suffix + ':\t$(CPPFILES) $(HPPFILES)')
         write('\t$(CC) ' + options + ' $(CCFLAGS) $(CPPFILES) $(LFLAGS) ' + _out + ident + suffix + _ext + '\n')
 
-        if sys.platform == 'darwin' and HOMEBREW and MATCH:
-            # static option
-            write('static: $(CPPFILES) $(HPPFILES)')
-            write(f'\t$(CC) {options} $(STATIC_CCFLAGS) $(CPPFILES) $(STATIC_LIBS) $(STATIC_LFLAGS) -o {ident}\n')
+    if sys.platform == 'darwin' and HOMEBREW and MATCH:
+        # static option
+        write('static: $(CPPFILES) $(HPPFILES)')
+        write(f'\t$(CC) $(STATIC_CCFLAGS) $(CPPFILES) $(STATIC_LIBS) $(STATIC_LFLAGS) -o {ident}\n')
 
     # clean
     ext = ''


### PR DESCRIPTION
This looks like a quick fix for the issue. It works for my demo case. Probably needs more testing.

If this fix is solid, then I suggest we focus on `PyMemberDef` vs `PyGetSetDef` (i.e. class member vars vs properties). Currently only properties are implemented not class members access. The question is in this case, is whether direct access of class members is required in the initial release.

It passed the extension mod tests  `tests/run -e`