### PR TITLE
Added `tests2` folder for named tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__
 .DS_Store
 *.pyc
 *.pyo

--- a/tests2/runtests.py
+++ b/tests2/runtests.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+import argparse
+import glob
+import os
+import subprocess
+import time
+import shutil
+from pathlib import Path
+
+try:
+    import pytest
+    HAVE_PYTEST = True
+except ImportError:
+    HAVE_PYTEST = False
+
+white = "\x1b[97;20m"
+GREY = "\x1b[38;20m"
+GREEN = "\x1b[32;20m"
+CYAN = "\x1b[36;20m"
+YELLOW = "\x1b[33;20m"
+RED = "\x1b[31;20m"
+RED_BOLD = "\x1b[31;1m"
+RESET = "\x1b[0m"
+
+class TestRunner:
+
+    def __init__(self, options):
+        self.options = options
+        self.tests = sorted(glob.glob("test_*.py"))
+
+    def check_output(self, args):
+        return subprocess.check_output(args.split(), 
+            stderr=subprocess.STDOUT
+        )
+
+    def run_step(self, cmd):
+        try:
+            self.check_output(cmd)
+        except subprocess.CalledProcessError as e:
+            print(f"\n{RED}ERROR{RESET}: '{cmd}' returns {e.returncode}")
+            print(e.output.decode('utf8'))
+            return
+
+    def validate(self, path):
+        with open(path) as f:
+            src = f.read()
+        compile(src, path, 'exec')
+
+    def run_test(self, path):
+        print(f'testing {path:30s}', end='')
+        path = Path(path)
+        name = path.stem
+
+        if self.options.validate:
+            self.validate(path) # check python syntax
+        self.run_step(f'shedskin {path}')
+        self.run_step('make')
+        self.run_step(f'./{name}')
+
+        print(f'{GREEN}OK{RESET}')
+
+        files_to_clean = [f'{name}.cpp', f'{name}.hpp', f'{name}', 'Makefile']
+        for f in files_to_clean:
+            os.remove(f)
+
+    def run_tests(self):
+        if HAVE_PYTEST:
+            os.system('pytest')
+            print()
+        print(f'Running {CYAN}shedskin{RESET} tests:')
+        st = time.time()
+        if self.options.recent: # run only most recently modified test
+            max_mtime = 0
+            most_recent_test = None
+            for test in self.tests:
+                mtime = os.stat(os.path.abspath(test)).st_mtime
+                if mtime > max_mtime:
+                    max_mtime = mtime
+                    most_recent_test = test
+            self.run_test(most_recent_test)
+        else:
+            for test in self.tests:
+                self.run_test(test)
+        et = time.time()
+        elapsed_time = round(et - st, 1)
+        print(f'Total test time: {YELLOW}{elapsed_time}{RESET} seconds\n')
+
+    @classmethod
+    def commandline(cls):
+        parser = argparse.ArgumentParser(
+            prog = 'runtests',
+            description = 'runs shedskin tests')
+        arg = opt = parser.add_argument
+        opt('-r', '--recent', help='run only most recently modified test', action='store_true')
+        opt('-v', '--validate', help='validate each testfile before running', action='store_true')
+        args = parser.parse_args()
+        runner = cls(args)
+        runner.run_tests()
+
+if __name__ == '__main__': TestRunner.commandline()
+

--- a/tests2/test_arguments.py
+++ b/tests2/test_arguments.py
@@ -1,0 +1,30 @@
+def baz(x, y, z = 3):
+    return x, y, z
+
+def boo(x, y, z='g'):
+    return x, y, z
+
+
+
+def test_t1():
+    assert baz(1, 2, 3) == (1, 2, 3)
+    assert baz(1, 3) == (1, 3, 3)
+
+def test_t2():
+    assert boo(z = 'z', y = 'y', x = 'x') == ('x', 'y', 'z')
+    assert boo(y = 'y', x = 'x') == ('x', 'y', 'g')
+    assert boo('x', y = 'y') == ('x', 'y', 'g')
+
+
+class A:
+    def foo(self, x = 3, y = 'hello'):
+        return x, y
+
+def test_t3():
+    assert A().foo(y = 'world', x = 42) == (42, 'world')
+
+
+if __name__ == '__main__':
+    test_t1()
+    test_t2()
+    test_t3()

--- a/tests2/test_assign.py
+++ b/tests2/test_assign.py
@@ -1,0 +1,14 @@
+
+def test_assign_int():
+    a = 1
+    assert a == 1
+
+def test_assign_list():
+    a = [1]
+    assert a == [1]
+
+
+if __name__ == '__main__':
+    test_assign_int()
+    test_assign_list()
+

--- a/tests2/test_class_basic.py
+++ b/tests2/test_class_basic.py
@@ -1,0 +1,39 @@
+class Fred:
+    a = 1
+    def speak(self, x):
+        return x
+
+    def huh(self):
+        self.b = 1
+
+    def hottum(self, x):
+        b = 4
+        return b
+
+def hottum():
+    pass
+
+
+def test_fred():
+    f = Fred()
+    assert f.a == 1
+
+    c = f.speak('goedzo?')
+    assert c == 'goedzo?'
+
+    f.huh()
+    assert f.b == f.a
+
+    f.hallo = 1
+    assert f.hallo == f.a
+
+    f2 = Fred()
+    f2.c = 'hello'
+    assert f2.c == 'hello'
+
+    h = Fred()
+    assert h.hottum('jo') == 4
+
+
+if __name__ == '__main__':
+    test_fred()

--- a/tests2/test_class_int.py
+++ b/tests2/test_class_int.py
@@ -1,0 +1,34 @@
+class Integer:
+    def __init__(self, x):
+        self.x = x
+
+    def __repr__(self):
+        return '<Integer: %s>' % self.x
+
+    def __gt__(self, other):
+        return self.x > other.x
+
+    def __gte__(self, other):
+        return self.x >= other.x
+    
+    def __lt__(self, other):
+        return self.x < other.x
+    
+    def __lte__(self, other):
+        return self.x <= other.x
+    
+
+def maxi(a, b):
+    if a > b:
+        return a
+    return b
+
+
+def test_int_class():
+    a = Integer(10)
+    b = Integer(12)
+    assert maxi(a, b) == b
+
+
+if __name__ == '__main__':
+    test_int_class()

--- a/tests2/test_class_object.py
+++ b/tests2/test_class_object.py
@@ -1,0 +1,37 @@
+# class Object:
+
+#     def __init__(self, name, *args, **kwds):
+#         self.name
+#         self.args = args
+#         self.kwds = kwds
+    
+#     def __str__(self):
+#         return f"<Object '{self.name}'>"
+    
+#     def __setitem__(self, name , value):
+#         self.kwds[name] = value
+    
+#     def __getitem__(self, name):
+#         if name in self.kwds:
+#             return self.kwds[name]
+    
+#     def __delitem__(self, name):
+#         if name in self.kwds:
+#             del self.kwds[name]
+    
+#     def __len__(self):
+#         return len(self.args)
+    
+#     def __contains__(self, name):
+#         if name in self.kwds:
+#             return True
+#         else:
+#             return False
+    
+
+def test_object():
+    assert 1+1 == 2
+
+if __name__ == '__main__':
+    test_basic()
+

--- a/tests2/test_class_point.py
+++ b/tests2/test_class_point.py
@@ -1,0 +1,79 @@
+
+class Point:   
+    def __init__(self, x , y):
+        self.x = x
+        self.y = y
+    
+    def __str__(self):
+        return '<Point(%s, %s)>' % (self.x, self.y)
+    
+    def __add__(self, other):
+        x = self.x + other.x
+        y = self.y + other.y
+        return Point(x, y)
+
+    def __sub__(self, other):
+        x = self.x - other.x
+        y = self.y - other.y
+        return Point(x, y)
+    
+    def __mul__(self, other):
+        x = self.x * other.x
+        y = self.y * other.y
+        return Point(x, y)
+    
+    def __truediv__(self, other):
+        x = self.x / other.x
+        y = self.y / other.y
+        return Point(x, y)
+    
+    def __floordiv__(self, other):
+        x = self.x // other.x
+        y = self.y // other.y
+        return Point(x, y)
+    
+    def __iadd__(self, other):
+        self.x += other.x
+        self.y += other.y
+        return self
+    
+    def __isub__(self, other):
+        self.x -= other.x
+        self.y -= other.y
+        return self
+    
+    def __imul__(self, other):
+        self.x *= other.x
+        self.y *= other.y
+        return self
+    
+    def __itruediv__(self, other):
+        self.x /= other.x
+        self.y /= other.y
+        return self
+
+
+def test_point():
+    p1 = Point(5, 5)
+    p2 = Point(10, 10)
+
+    assert str(p1) == '<Point(5, 5)>'
+
+    p3 = p1 + p2
+    assert p3.x == 15 and p3.y == 15
+
+    p4 = p3 * p2
+    assert p4.x == 150 and p4.y == 150
+
+    p5 = p4 - p2
+    assert p5.x == 140 and p5.y == 140
+
+    p6 = p5 // p2 # floor division
+    assert p6.x == 14 and p6.y == 14
+
+    # p7 = p5 / p2 # true division
+    # assert int(p7.x) == 14 and int(p7.y) == 14
+
+
+if __name__ == '__main__':
+    test_point()

--- a/tests2/test_float.py
+++ b/tests2/test_float.py
@@ -1,0 +1,9 @@
+x = 1.0
+
+
+def test_float():
+    assert x == 1.0
+
+
+if __name__ == '__main__':
+    test_float()

--- a/tests2/test_func_basic.py
+++ b/tests2/test_func_basic.py
@@ -1,0 +1,79 @@
+
+def ident(x):
+    return x
+
+def boing(c, d):
+    return ident(c)
+
+def bla():
+    return 8
+
+def bwa():
+    d = 'hoi'
+    return d
+
+def aap(y):
+    return y
+
+def hap(y):
+    return y
+
+class xevious:
+    def solvalou(self, x):
+        return x
+
+def pacman(a):
+    return 1
+
+def qbert():
+    c = 1
+    a = 1
+    pacman(a)
+    b = 1
+    a = c
+    d = 1
+    e = 1
+    x = xevious()
+    x.y = d
+    x.z = 'hoi'
+    x.solvalou(e)
+
+    return b
+
+def test_basic():
+    assert boing(1, 1.0) == 1
+
+def test_nested():
+    a = 1
+    h = boing(boing(a, 1.0), boing(3.0, a))
+    assert h == 1
+
+def test_local():
+    assert qbert() == 1
+
+def test_return_int():
+    assert bla() == 8
+
+def test_return_int_param():
+    assert aap(100) == 100
+
+def test_return_str():
+    assert bwa() == 'hoi'
+
+def test_return_float():
+    assert hap(1.0) == 1.0
+
+
+
+
+
+if __name__ == '__main__':
+    test_basic()
+    test_nested()
+    test_local()
+    test_return_int()
+    test_return_int_param()
+    test_return_str()
+    test_return_float()
+
+

--- a/tests2/test_list.py
+++ b/tests2/test_list.py
@@ -1,0 +1,34 @@
+#class list:                              # unit: [float]*
+#    def append(self, x):                 # x: [float], self: [list_float]
+#        self.unit = x                    # [float]
+#
+#    def __getitem__(self, i):            # i: [int], a: [float], self: [list_float]
+#        a = self.unit                    # [float]
+#        return a                         # [float]
+
+list1 = []
+list1.append(1.0)
+
+list2 = []
+list2.append(1)
+
+list3 = []
+list3.append("astring")
+
+list4 = [(1,2),(3,4)]
+
+
+def test_list_append():
+    assert list1[0] == 1.0
+    assert list2[0] == 1
+    assert list3[0] == "astring"
+
+
+def test_tuple_in_list():
+    assert (1,2) in list4
+
+
+
+if __name__ == '__main__':
+    test_list_append()
+    test_tuple_in_list()

--- a/tests2/test_str.py
+++ b/tests2/test_str.py
@@ -1,0 +1,17 @@
+class Sequence:
+    def __init__(self, seq='wxyz'):
+        self.seq = seq
+
+    def __len__(self):
+        return len(self.seq)
+
+    def __getitem__(self, i):
+        return self.seq[i]
+
+def test_str():
+    s = Sequence()
+    assert len(s) == 4
+    assert s[0] == 'w'
+
+if __name__ == '__main__':
+    test_str()

--- a/tests2/test_tuple.py
+++ b/tests2/test_tuple.py
@@ -1,0 +1,13 @@
+
+def gettuple():
+    return (5,6)
+
+
+def test_tuple():
+    a = gettuple()
+    assert [(1,2),(3,4), a, gettuple()] == [(1,2), (3,4), (5,6), (5,6)]
+
+
+
+if __name__ == '__main__':
+    test_tuple()

--- a/tests2/test_types.py
+++ b/tests2/test_types.py
@@ -1,0 +1,11 @@
+
+def test_equality():
+    assert int(1) == int(1)
+    assert int(1.0) == int(1.0)
+    assert float(1) == float(1)
+    assert float(1.0) == float(1.0)
+
+
+if __name__ == '__main__':
+    test_equality()
+    


### PR DESCRIPTION
I've added another tests folder `tests2` named tests, as I have found the numbered tests in the current `tests` folder difficult to follow and classify. The proposal here is to keep two folders and eventually migrate the first to `tests2` style.

- Each test is a python test file named `test_<name>.py` and includes test functions with the typical `test_<name>()` naming convention. This allows the tests to be tested in python for correctness (e.g. `pytests`, etc..) and external python tests to be quickly incorporated into the test suite.

- Each test function should include an `assert` to test specific case

- Group related tests together by subject and by file name.

- Run all test functions in the `__name__ == '__main__'` section

There's a basic `runtests.py` test runner to help with the above.
