### PR TITLE
tests2(cmake): Fix for local imports

### DIFF
--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -98,7 +98,6 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
     def __init__(self, gx, module):
         self.gx = gx
         self.output_base = module.filename[:-3]
-        # self.out = open(self.output_base + '.cpp', 'w')
         self.out = self.get_output_file(ext='.cpp')
         self.indentation = ''
         self.consts = {}
@@ -143,7 +142,6 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
 
         with self.get_output_file(ext=suffix, mode='r') as f:
             lines = f.readlines()
-        # lines = open(self.output_base + suffix, 'r').readlines()
         newlines = []
         j = -1
         for (i, line) in enumerate(lines):
@@ -193,7 +191,6 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
 
         with self.get_output_file(ext=suffix, mode='w') as f:
             f.writelines(newlines2)
-        # open(self.output_base + suffix, 'w').writelines(newlines2)
         self.filling_consts = False
 
     def insert_extras(self, suffix):
@@ -209,7 +206,6 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
                 newlines.extend(self.fwd_class_refs())
         with self.get_output_file(ext=suffix, mode='w') as f:
             f.writelines(newlines)
-        # open(self.output_base + suffix, 'w').writelines(newlines)
 
     def fwd_class_refs(self):
         lines = []
@@ -281,7 +277,6 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
         return result
 
     def header_file(self):
-        # self.out = open(self.output_base + '.hpp', 'w')
         self.out = self.get_output_file(ext='.hpp')
         self.visit(self.module.ast, True)
         self.out.close()

--- a/tests2/scripts/fn_add_shedskin_exe_import_test.cmake
+++ b/tests2/scripts/fn_add_shedskin_exe_import_test.cmake
@@ -1,5 +1,5 @@
 
-function(add_shedskin_test modules)
+function(add_shedskin_test sys_modules)
 
     get_filename_component(name ${CMAKE_CURRENT_SOURCE_DIR} NAME_WLE)
 
@@ -23,35 +23,50 @@ function(add_shedskin_test modules)
 
     add_custom_target(shedskin_${APP} DEPENDS ${translated_files})
 
-    list(PREPEND modules builtin)
+    list(PREPEND sys_modules builtin)
 
-    foreach(mod ${modules})
+    foreach(mod ${sys_modules})
         # special case os and os.path
         if(mod STREQUAL "os")
-            list(APPEND module_list "${SHEDSKIN_LIB}/os/__init__.cpp")
-            list(APPEND module_list "${SHEDSKIN_LIB}/os/__init__.hpp")            
+            list(APPEND sys_module_list "${SHEDSKIN_LIB}/os/__init__.cpp")
+            list(APPEND sys_module_list "${SHEDSKIN_LIB}/os/__init__.hpp")            
         elseif(mod STREQUAL "os.path")
-            list(APPEND module_list "${SHEDSKIN_LIB}/os/path.cpp")
-            list(APPEND module_list "${SHEDSKIN_LIB}/os/path.hpp")
+            list(APPEND sys_module_list "${SHEDSKIN_LIB}/os/path.cpp")
+            list(APPEND sys_module_list "${SHEDSKIN_LIB}/os/path.hpp")
         else()
-            list(APPEND module_list "${SHEDSKIN_LIB}/${mod}.cpp")
-            list(APPEND module_list "${SHEDSKIN_LIB}/${mod}.hpp")
+            list(APPEND sys_module_list "${SHEDSKIN_LIB}/${mod}.cpp")
+            list(APPEND sys_module_list "${SHEDSKIN_LIB}/${mod}.hpp")
         endif()
+    endforeach()
+
+    if(ARGV1)
+        set(app_modules ${ARGV1})
+    else()
+        set(app_modules)
+    endif()
+    foreach(mod ${app_modules})
+        list(APPEND app_module_list "${PROJECT_BINARY_DIR}/${mod}.cpp")
+        list(APPEND app_module_list "${PROJECT_BINARY_DIR}/${mod}.hpp")            
     endforeach()
 
     if(DEBUG)
         message("-------------------------------------------------------------")
         message("name:" ${name})
-        foreach(mod ${module_list})
+        foreach(mod ${app_module_list})
             get_filename_component(mod_name ${mod} NAME)
-            message("module: ${mod_name}") 
+            message("app_module: ${mod_name}") 
+        endforeach()
+        foreach(mod ${sys_module_list})
+            get_filename_component(mod_name ${mod} NAME)
+            message("sys_module: ${mod_name}") 
         endforeach()
     endif()
 
     add_executable(${APP}
         ${PROJECT_BINARY_DIR}/${APP_NAME}.cpp
         ${PROJECT_BINARY_DIR}/${APP_NAME}.hpp
-        ${module_list}
+        ${app_module_list}        
+        ${sys_module_list}
     )
 
     target_include_directories(${APP} PRIVATE

--- a/tests2/scripts/fn_add_shedskin_ext_import_test.cmake
+++ b/tests2/scripts/fn_add_shedskin_ext_import_test.cmake
@@ -1,5 +1,5 @@
 
-function(add_shedskin_test modules)
+function(add_shedskin_test sys_modules)
 
     get_filename_component(name ${CMAKE_CURRENT_SOURCE_DIR} NAME_WLE)
 
@@ -21,9 +21,9 @@ function(add_shedskin_test modules)
 
     add_custom_target(shedskin_ext_import_${PYEXT} DEPENDS ${translated_files})
 
-    list(PREPEND modules builtin)
+    list(PREPEND sys_modules builtin)
 
-    foreach(mod ${modules})
+    foreach(mod ${sys_modules})
         # special case os and os.path
         if(mod STREQUAL "os")
             list(APPEND module_list "${SHEDSKIN_LIB}/os/__init__.cpp")
@@ -37,19 +37,34 @@ function(add_shedskin_test modules)
         endif()
     endforeach()
 
+    if(ARGV1)
+        set(app_modules ${ARGV0})
+    else()
+        set(app_modules)
+    endif()
+    foreach(mod ${app_modules})
+        list(APPEND app_module_list "${PROJECT_BINARY_DIR}/${mod}.cpp")
+        list(APPEND app_module_list "${PROJECT_BINARY_DIR}/${mod}.hpp")            
+    endforeach()
+
     if(DEBUG)
         message("-------------------------------------------------------------")
         message("name:" ${name})
-        foreach(mod ${module_list})
+        foreach(mod ${app_module_list})
             get_filename_component(mod_name ${mod} NAME)
-            message("module: ${mod_name}") 
+            message("app_module: ${mod_name}") 
+        endforeach()
+        foreach(mod ${sys_module_list})
+            get_filename_component(mod_name ${mod} NAME)
+            message("sys_module: ${mod_name}") 
         endforeach()
     endif()
 
     add_library(${PYEXT} MODULE
         ${PROJECT_BINARY_DIR}/${PYEXT}.cpp
         ${PROJECT_BINARY_DIR}/${PYEXT}.hpp
-        ${module_list}
+        ${app_module_list}        
+        ${sys_module_list}
     )
 
     set_target_properties(${PYEXT} PROPERTIES

--- a/tests2/test_func_lambda.py
+++ b/tests2/test_func_lambda.py
@@ -1,0 +1,45 @@
+
+def foo(l):
+    return l(1, 2)
+
+def f1(x,y):
+    return x+y
+
+def f2(x,y):
+    return x-y
+
+def f3(x,y):
+    return 1.0
+
+def f4(x,y):
+    return f1(x,y)
+
+def test_funcs():
+    assert f1(10,2) == 12
+    assert f2(10,2) == 8
+    assert f3(10,2) == 1.0
+    assert f4(10,2) == 12  ## only an issue with lambdas!
+
+
+def test_lambdas():
+    l1 = lambda x, y: x + y
+
+    l2 = lambda x, y: x - y
+    
+    l3 = lambda x, y: 1.0
+    
+    # l4 = lambda x, y: l1(x,y) ## FIXME: uncomment to cause a strange error with l3!
+
+    assert l1(10,2) == 12
+    assert l2(10,2) == 8
+    assert l3(10,2) == 1.0
+
+    # assert l4(10,2) == 12
+
+def test_all():
+    test_funcs()
+    test_lambdas()
+
+
+if __name__ == '__main__':
+    test_all() 

--- a/tests2/test_import/CMakeLists.txt
+++ b/tests2/test_import/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(sys_modules
+)
+
+set(app_modules
+	foo
+	bar
+	spam
+)
+
+add_shedskin_test("${sys_modules}" "${app_modules}")

--- a/tests2/test_import/bar.py
+++ b/tests2/test_import/bar.py
@@ -1,0 +1,11 @@
+from spam import Spam
+
+
+class Bar:
+    """a bar class"""
+
+    def __init__(self):
+        self.spam = Spam()
+
+    def name(self):
+        return self.spam.name()

--- a/tests2/test_import/foo.py
+++ b/tests2/test_import/foo.py
@@ -1,0 +1,11 @@
+from bar import Bar
+
+
+class Foo:
+    """a foo class"""
+
+    def __init__(self):
+        self.bar = Bar()
+
+    def name(self):
+        return self.bar.name()

--- a/tests2/test_import/spam.py
+++ b/tests2/test_import/spam.py
@@ -1,0 +1,8 @@
+class Spam:
+    """a spame class"""
+
+    def __init__(self):
+        self._name = "hello"
+
+    def name(self):
+        return self._name

--- a/tests2/test_import/test_import.py
+++ b/tests2/test_import/test_import.py
@@ -1,0 +1,29 @@
+"""
+Eggs <- Foo <- Bar <- Spam
+
+"""
+
+
+from foo import Foo
+
+
+class Eggs:
+    def __init__(self):
+        self.foo = Foo()
+
+    def name(self):
+        return self.foo.name()
+
+
+def test_imports():
+    eggs = Eggs()
+    print(eggs.name())
+    assert eggs.name() == "hello"
+
+
+def test_all():
+    test_imports()
+
+
+if __name__ == "__main__":
+    test_all()

--- a/tests2/test_types.py
+++ b/tests2/test_types.py
@@ -1,3 +1,28 @@
+# class evert:
+#     pass
+
+
+# bla = evert()
+
+# cl = bla.__class__
+
+# print(cl)
+# print(cl.__name__)
+
+# print(type(bla))
+# print(type(bla).__name__)
+
+# if cl == type(evert()):
+#     print("equal!")
+
+# if type("2") == type("3"):
+#     print("equal str!")
+
+# if type(1) == type("1"):
+#     print("equal non-equal!")
+
+
+
 def test_equality():
     assert int(1) == int(1)
     assert int(1.0) == int(1.0)


### PR DESCRIPTION
This is a fix for "test2 cmake machinery does not support multiple local module dependencies (a -> b -> c -> ...) while the builtin shedskin makefile build does."

The fix is demonstrated in `tests2/test_import/CMakeLists.txt`:

```cmake
set(sys_modules
)

set(app_modules
	foo
	bar
	spam
)

add_shedskin_test("${sys_modules}" "${app_modules}")
```

Of course, all of the above should generated automatically once the we have a `cmake.py` version of the `makefile.py`
