### PR TITLE
restore mistakenly deleted cmake ..

### DIFF
--- a/tests2/runtests.py
+++ b/tests2/runtests.py
@@ -133,6 +133,7 @@ class TestRunner:
                 cmake_cmd = "cmake --build ."
             actions = [
                 "cd build",
+                "cmake ..",
                 cmake_cmd,
                 "ctest"
             ]


### PR DESCRIPTION
I mistakenly deleted `cmake ..` from the build/run sequence in my last commit. This PR restores it.

