### PR TITLE
Fix for Windows support to build shedskin executables via cmake (shedskin build)

### DIFF
--- a/shedskin/extmod.py
+++ b/shedskin/extmod.py
@@ -65,7 +65,7 @@ class ExtensionModule:
         :rtype:     { return_type_description }
         """
         for module in self.gx.modules.values():
-            if not module.builtin and not module is self.gv.module:
+            if not module.builtin and module is not self.gv.module:
                 self.write(
                     "    %s::%s%s();"
                     % (module.full_path(), what, "_".join(module.name_list))
@@ -75,7 +75,7 @@ class ExtensionModule:
         """XXX currently only classs / instance variables"""
         supported = []
         for var in variables:
-            if not var in self.gx.merged_inh or not self.gx.merged_inh[var]:
+            if var not in self.gx.merged_inh or not self.gx.merged_inh[var]:
                 continue
             if var.name is None or var.name.startswith("__"):  # XXX
                 continue
@@ -395,7 +395,7 @@ class ExtensionModule:
             else:
                 write("    0,")
         write("};\n")
-        if cl and not python.def_class(self.gx, "Exception") in cl.ancestors():
+        if cl and python.def_class(self.gx, "Exception") not in cl.ancestors():
             write(
                 "PyObject *%s__reduce__(PyObject *self, PyObject *args, PyObject *kwargs);"
                 % ident
@@ -409,7 +409,7 @@ class ExtensionModule:
             write(
                 '    {(char *)"__newobj__", (PyCFunction)__ss__newobj__, METH_VARARGS | METH_KEYWORDS, (char *)""},'
             )
-        elif cl and not python.def_class(self.gx, "Exception") in cl.ancestors():
+        elif cl and python.def_class(self.gx, "Exception") not in cl.ancestors():
             write(
                 '    {(char *)"__reduce__", (PyCFunction)%s__reduce__, METH_VARARGS | METH_KEYWORDS, (char *)""},'
                 % ident
@@ -842,7 +842,8 @@ class ExtensionModule:
         """
         { function_description }
         """
-        write = lambda s: print(s, file=self.gv.out)
+        def write(s):
+            return print(s, file=self.gv.out)
 
         for cl in self.exported_classes():
             write('extern "C" PyTypeObject %sObjectType;' % clname(cl))

--- a/shedskin/lib/builtin/format.cpp
+++ b/shedskin/lib/builtin/format.cpp
@@ -1,5 +1,12 @@
 /* Copyright 2005-2011 Mark Dufour and contributors; License Expat (See LICENSE) */
 
+
+#if defined(WIN32)
+#include <BaseTsd.h>
+#include <stdlib.h>
+typedef SSIZE_T ssize_t
+#endif
+
 /* mod helpers */
 
 #if defined(_WIN32) || defined(WIN32) || defined(__sun)

--- a/shedskin/lib/builtin/format.cpp
+++ b/shedskin/lib/builtin/format.cpp
@@ -4,15 +4,15 @@
 #if defined(WIN32)
 #include <BaseTsd.h>
 #include <stdlib.h>
-typedef SSIZE_T ssize_t
+typedef SSIZE_T ssize_t;
 #endif
 
 /* mod helpers */
 
 #if defined(_WIN32) || defined(WIN32) || defined(__sun)
-#   if defined (_MSC_VER)
-#       define va_copy(dest, src) ((void)((dest) = (src)))
-#   endif
+#if defined (_MSC_VER)
+#define va_copy(dest, src) ((void)((dest) = (src)));
+#endif
 int vasprintf(char **ret, const char *format, va_list ap)
 {
     va_list ap2;

--- a/shedskin/resources/cmake/modular/fn_add_shedskin_executable.cmake
+++ b/shedskin/resources/cmake/modular/fn_add_shedskin_executable.cmake
@@ -290,6 +290,7 @@ function(add_shedskin_executable)
         $<$<BOOL:${UNIX}>:-Wno-unused-variable>
         $<$<BOOL:${UNIX}>:-Wno-unused-but-set-variable>
         ${SHEDSKIN_COMPILE_OPTIONS}
+        $<$<BOOL:${WIN32}>:/MD>
     )
 
     target_include_directories(${EXE} PRIVATE

--- a/shedskin/resources/cmake/modular/fn_add_shedskin_product.cmake
+++ b/shedskin/resources/cmake/modular/fn_add_shedskin_product.cmake
@@ -331,6 +331,7 @@ function(add_shedskin_product)
             $<$<BOOL:${UNIX}>:-Wno-unused-variable>
             $<$<BOOL:${UNIX}>:-Wno-unused-but-set-variable>
             ${SHEDSKIN_COMPILE_OPTIONS}
+            $<$<BOOL:${WIN32}>:/MD>
         )
 
         target_include_directories(${EXE} PRIVATE

--- a/shedskin/resources/cmake/single/fn_add_shedskin_executable.cmake
+++ b/shedskin/resources/cmake/single/fn_add_shedskin_executable.cmake
@@ -290,6 +290,7 @@ function(add_shedskin_executable)
         $<$<BOOL:${UNIX}>:-Wno-unused-variable>
         $<$<BOOL:${UNIX}>:-Wno-unused-but-set-variable>
         ${SHEDSKIN_COMPILE_OPTIONS}
+        $<$<BOOL:${WIN32}>:/MD>
     )
 
     target_include_directories(${EXE} PRIVATE

--- a/shedskin/resources/cmake/single/fn_add_shedskin_product.cmake
+++ b/shedskin/resources/cmake/single/fn_add_shedskin_product.cmake
@@ -331,6 +331,8 @@ function(add_shedskin_product)
             $<$<BOOL:${UNIX}>:-Wno-unused-variable>
             $<$<BOOL:${UNIX}>:-Wno-unused-but-set-variable>
             ${SHEDSKIN_COMPILE_OPTIONS}
+            $<$<BOOL:${WIN32}>:/MD>
+            $<$<BOOL:${WIN32}>:/NODEFAULTLIB:library>
         )
 
         target_include_directories(${EXE} PRIVATE


### PR DESCRIPTION
After some experimentation on a windows machine, I managed to introduce win32 platform-specific flags at the cmake level which enable building executables.

The works (requires) Visual Studio Community edition to be installed on the windows machine.