### PR TITLE
added custom cmake options to test

### DIFF
--- a/shedskin/__init__.py
+++ b/shedskin/__init__.py
@@ -348,6 +348,8 @@ class Shedskin:
         opt('--ccache',           help='enable ccache with cmake', action='store_true')
         opt('--target',           help='build only specified cmake targets', nargs="+", metavar="TARGET")
 
+        opt("-c", "--cfg",        help="Add a cmake option '-D' prefix not needed", nargs='*', metavar="CMAKE_OPT")
+
         # make 'translate' the default subparser
         for arg in sys.argv[1:]:
             if arg in ('-h', '--help'):

--- a/shedskin/cmake.py
+++ b/shedskin/cmake.py
@@ -573,7 +573,7 @@ class CMakeBuilder:
         """process shedskin program with cmake"""
         start_time = time.time()
 
-        cfg_options = []
+        cfg_options = [] if not self.options.cfg else [f'-D{opt}' for opt in self.options.cfg]
         bld_options = []
         tst_options = []
 


### PR DESCRIPTION
Can now the following:

```bash
shedskin test --conan -c'Python_ROOT_DIR="$pythonLocation"'
```

will add a cmake options as if:

```bash
cd build 
cmake .. -DPython_ROOT_DIR="$pythonLocation"
```

`-c` can be repeated as many times as required.

```bash
shedskin test --help
...
  -c [CMAKE_OPT ...], --cfg [CMAKE_OPT ...]
                        Add a cmake option '-D' prefix not needed
```