### PR TITLE
fix for --lib

### DIFF
--- a/examples/msp_ss/CMakeLists.txt
+++ b/examples/msp_ss/CMakeLists.txt
@@ -1,6 +1,7 @@
 # more complex case
 add_shedskin_product(
-    HAS_LIB
+    EXTRA_LIB_DIR
+        lib
 
     SYS_MODULES
         getopt

--- a/examples/rsync/CMakeLists.txt
+++ b/examples/rsync/CMakeLists.txt
@@ -19,7 +19,8 @@ endif()
 
 
 add_shedskin_product(
-    HAS_LIB
+    EXTRA_LIB_DIR
+        lib
 
     SYS_MODULES
         collections

--- a/examples/sha/CMakeLists.txt
+++ b/examples/sha/CMakeLists.txt
@@ -19,7 +19,8 @@ endif()
 
 
 add_shedskin_product(
-    HAS_LIB
+    EXTRA_LIB_DIR
+        lib
 
     SYS_MODULES
         copy

--- a/shedskin/__init__.py
+++ b/shedskin/__init__.py
@@ -140,9 +140,8 @@ class Shedskin:
             if args.executable:
                 gx.executable_product = True
 
-            # [str]
             if args.lib:
-                gx.libdirs = args.lib + gx.libdirs
+                gx.libdirs = [args.lib] + gx.libdirs
 
             # str
             if args.flags:
@@ -224,7 +223,7 @@ class Shedskin:
         opt("-e", "--extmod",     help="Generate extension module", action="store_true")
         opt("-f", "--float",      help="Use 32-bit floating point numbers", action="store_true")
         opt("-F", "--flags",      help="Provide alternate Makefile flags")
-        opt("-L", "--lib",        help="Add a library directory", nargs='*')
+        opt("-L", "--lib",        help="Add an extra library directory")
         opt("-l", "--long",       help="Use long long '64-bit' integers", action="store_true")
         opt("-m", "--makefile",   help="Specify alternate Makefile name")
         opt("-o", "--outputdir",  help="Specify output directory for generated files")
@@ -262,7 +261,7 @@ class Shedskin:
         opt("-e", "--extmod",     help="Generate extension module", action="store_true")
         opt("-f", "--float",      help="Use 32-bit floating point numbers", action="store_true")
         opt("-F", "--flags",      help="Provide alternate Makefile flags")
-        opt("-L", "--lib",        help="Add a library directory", nargs='*')
+        opt("-L", "--lib",        help="Add an extra library directory")
         opt("-l", "--long",       help="Use long long '64-bit' integers", action="store_true")
         opt("-m", "--makefile",   help="Specify alternate Makefile name")
         opt("-o", "--outputdir",  help="Specify output directory for generated files")
@@ -300,7 +299,7 @@ class Shedskin:
         opt("-e", "--extmod",     help="Generate extension module", action="store_true")
         opt("-f", "--float",      help="Use 32-bit floating point numbers", action="store_true")
         opt("-F", "--flags",      help="Provide alternate Makefile flags")
-        opt("-L", "--lib",        help="Add a library directory", nargs='*')
+        opt("-L", "--lib",        help="Add an extra library directory")
         opt("-l", "--long",       help="Use long long '64-bit' integers", action="store_true")
         opt("-m", "--makefile",   help="Specify alternate Makefile name")
         opt("-o", "--outputdir",  help="Specify output directory for generated files")

--- a/shedskin/cmake.py
+++ b/shedskin/cmake.py
@@ -274,12 +274,13 @@ def add_shedskin_product(
     disable_executable=False,
     disable_extension=False,
     disable_test=False,
-    has_lib=False,
+    # has_lib=False,
     enble_conan=False,
     enable_externalproject=False,
     enable_spm=False,
     debug=False,
     name=None,
+    extra_lib_dir=None,
 ):
     """populates a cmake function with the same name
 
@@ -301,6 +302,7 @@ def add_shedskin_product(
         SYS_MODULES APP_MODULES DATA
         INCLUDE_DIRS LINK_LIBS LINK_DIRS
         COMPILE_OPTIONS LINK_OPTIONS CMDLINE_OPTIONS
+        EXTRA_LIB_DIRS
     """
 
     def mk_add(lines, spaces=4):
@@ -335,9 +337,6 @@ def add_shedskin_product(
     elif enable_spm:
         add(1, "ENABLE_SPM")
 
-    if has_lib:
-        add(1, "HAS_LIB")
-
     if debug:
         add(1, "DEBUG")
 
@@ -346,6 +345,9 @@ def add_shedskin_product(
 
     if main_module:
         add(1, f"MAIN_MODULE {main_module}")
+
+    if extra_lib_dir:
+        add(1, f"EXTRA_LIB_DIR {extra_lib_dir}")
 
     if include_dirs:
         add(1, f"INCLUDE_DIRS {include_dirs}")
@@ -382,13 +384,6 @@ def add_shedskin_product(
     add(0, ")")
     return "\n".join(flist)
 
-
-# def get_cmakefile_template(section, **kwds):
-#     """returns a cmake template"""
-#     _pkg_path = get_pkg_path()
-#     cmakelists_tmpl = _pkg_path / "resources" / "cmake" / section / "CMakeLists.txt"
-#     tmpl = cmakelists_tmpl.read_text()
-#     return tmpl % kwds
 
 def get_cmakefile_template(**kwds):
     """returns a cmake template"""
@@ -440,6 +435,8 @@ def generate_cmakefile(gx):
                 name=path.stem,
                 build_executable=gx.executable_product,
                 build_extension=gx.pyextension_product,
+                extra_lib_dir=gx.options.lib,
+                # has_lib=gx.options.lib,
             ),
         )
         master_clfile.write_text(master_clfile_content)
@@ -454,6 +451,7 @@ def generate_cmakefile(gx):
                 app_mods,
                 build_executable=gx.executable_product,
                 build_extension=gx.pyextension_product,
+                extra_lib_dir=gx.options.lib,
             )
         )
 

--- a/shedskin/resources/cmake/fn_add_shedskin_product.cmake
+++ b/shedskin/resources/cmake/fn_add_shedskin_product.cmake
@@ -20,7 +20,6 @@ function(add_shedskin_product)
         BUILD_EXECUTABLE
         BUILD_EXTENSION
         BUILD_TEST
-        HAS_LIB
         ENABLE_CONAN
         ENABLE_SPM
         ENABLE_EXTERNAL_PROJECT
@@ -29,6 +28,7 @@ function(add_shedskin_product)
     set(oneValueArgs
         NAME
         MAIN_MODULE
+        EXTRA_LIB_DIR
     )
     set(multiValueArgs 
         SYS_MODULES
@@ -132,8 +132,6 @@ function(add_shedskin_product)
             SHEDSKIN_BUILD_EXTENSION
             SHEDSKIN_BUILD_TEST
 
-            SHEDSKIN_HAS_LIB
-
             SHEDSKIN_ENABLE_CONAN
             SHEDSKIN_ENABLE_SPM
             SHEDSKIN_ENABLE_EXTERNAL_PROJECT
@@ -142,6 +140,7 @@ function(add_shedskin_product)
             # one value args
             SHEDSKIN_NAME
             SHEDSKIN_MAIN_MODULE
+            SHEDSKIN_EXTRA_LIB_DIR
             
             # multi value args
             SHEDSKIN_SYS_MODULES
@@ -155,7 +154,7 @@ function(add_shedskin_product)
             SHEDSKIN_LINK_LIBS
 
             SHEDSKIN_CMDLINE_OPTIONS
-            
+
             # intermediate variables
             name
             main
@@ -308,8 +307,12 @@ function(add_shedskin_product)
 
         add_custom_target(shedskin_${EXE} DEPENDS ${translated_files})
 
-        if(SHEDSKIN_HAS_LIB AND NOT EXISTS ${PROJECT_EXE_DIR}/lib)
-            file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/lib DESTINATION ${PROJECT_EXE_DIR})
+        # if(SHEDSKIN_HAS_LIB AND NOT EXISTS ${PROJECT_EXE_DIR}/lib)
+        #     file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/lib DESTINATION ${PROJECT_EXE_DIR})
+        # endif()
+
+        if(SHEDSKIN_EXTRA_LIB_DIR AND NOT EXISTS ${PROJECT_EXE_DIR}/${SHEDSKIN_EXTRA_LIB_DIR})
+            file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/${SHEDSKIN_EXTRA_LIB_DIR} DESTINATION ${PROJECT_EXE_DIR})
         endif()
 
         add_executable(${EXE}
@@ -409,8 +412,12 @@ function(add_shedskin_product)
 
         add_custom_target(shedskin_${EXT} DEPENDS ${translated_files})
 
-        if(SHEDSKIN_HAS_LIB AND NOT EXISTS ${PROJECT_EXT_DIR}/lib)
-            file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/lib DESTINATION ${PROJECT_EXT_DIR})
+        # if(SHEDSKIN_HAS_LIB AND NOT EXISTS ${PROJECT_EXT_DIR}/lib)
+        #     file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/lib DESTINATION ${PROJECT_EXT_DIR})
+        # endif()
+
+        if(SHEDSKIN_EXTRA_LIB_DIR AND NOT EXISTS ${PROJECT_EXT_DIR}/${SHEDSKIN_EXTRA_LIB_DIR})
+            file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/${SHEDSKIN_EXTRA_LIB_DIR} DESTINATION ${PROJECT_EXT_DIR})
         endif()
 
         add_library(${EXT} MODULE


### PR DESCRIPTION
`shedskin build -L<name-of-lib>` or `shedskin --lib=<name-of-lib>` is now working properly. 

- It is does not allow many inputs as before just a single 'extra-lib-dir`.  
- There is also a corresponding option in CMakeLists.txt `EXTRA_LIB_DIR`.
-  examples have been modified accordingly to work with this change


