### PR TITLE
Includes a number of fixes 

### DIFF
--- a/shedskin/__init__.py
+++ b/shedskin/__init__.py
@@ -70,7 +70,7 @@ class Shedskin:
 
     def configure(self, args: argparse.Namespace):
         # print(args)
-        gx = config.GlobalInfo()
+        gx = config.GlobalInfo(args)
 
         if args.subcmd in ['build', 'run', 'test']:
             # ensure cmake is available and installed.
@@ -225,7 +225,7 @@ class Shedskin:
         opt("-d", "--debug",        help="Set debug level", type=int)
         opt("-e", "--extmod",       help="Generate extension module", action="store_true")
         opt("-F", "--flags",        help="Provide alternate Makefile flags")
-        opt("-I", "--include-dirs", help="Add an include directory", action="append")        
+        opt("-I", "--include-dirs", help="Add an include directory", action="append")
         opt("-L", "--link-dirs",    help="Add a link library directory", action="append")
         opt("-l", "--link-libs",    help="Add a link library", action="append")
         opt("-X", "--extra-lib",    help="Add an extra builtins library directory")
@@ -267,7 +267,7 @@ class Shedskin:
 
         opt("-d", "--debug",        help="Set debug level", type=int)
         opt("-e", "--extmod",       help="Generate extension module", action="store_true")
-        opt("-I", "--include-dirs", help="Add an include directory", action="append")        
+        opt("-I", "--include-dirs", help="Add an include directory", action="append")
         opt("-L", "--link-dirs",    help="Add a link library directory", action="append")
         opt("-l", "--link-libs",    help="Add a link library", action="append")
         opt("-X", "--extra-lib",    help="Add an extra builtins library directory")
@@ -308,7 +308,7 @@ class Shedskin:
 
         opt("-d", "--debug",        help="Set debug level", type=int)
         opt("-e", "--extmod",       help="Generate extension module", action="store_true")
-        opt("-I", "--include-dirs", help="Add an include directory", action="append")        
+        opt("-I", "--include-dirs", help="Add an include directory", action="append")
         opt("-L", "--link-dirs",    help="Add a link library directory", action="append")
         opt("-l", "--link-libs",    help="Add a link library", action="append")
         opt("-X", "--extra-lib",    help="Add an extra builtins library directory")
@@ -327,7 +327,7 @@ class Shedskin:
         opt("--noassert",           help="Disable assert statements", action="store_true")
         opt("--nobounds",           help="Disable bounds checking", action="store_true")
         opt("--nogc",               help="Disable garbage collection", action="store_true")
-        opt("--nowarnings",         help="Disable '-Wall' compilation warnings", action="store_true")        
+        opt("--nowarnings",         help="Disable '-Wall' compilation warnings", action="store_true")
         opt("--nowrap",             help="Disable wrap-around checking", action="store_true")
 
         parser_test = subparsers.add_parser('test', help="run tests")
@@ -362,7 +362,7 @@ class Shedskin:
         opt('--target',           help='build only specified cmake targets', nargs="+", metavar="TARGET")
 
         opt("-c", "--cfg",        help="Add a cmake option '-D' prefix not needed", nargs='*', metavar="CMAKE_OPT")
-        opt("--nowarnings",       help="Disable '-Wall' compilation warnings", action="store_true")        
+        opt("--nowarnings",       help="Disable '-Wall' compilation warnings", action="store_true")
 
         # make 'translate' the default subparser
         for _arg in sys.argv[1:]:

--- a/shedskin/cmake.py
+++ b/shedskin/cmake.py
@@ -187,7 +187,7 @@ class ShedskinDependencyManager:
         print(f"{WHITE}cmd{RESET}: {CYAN}{cmd}{RESET}")
         os.system(cmd.format(*args, **kwds))
 
-    def git_clone(self, repo: str, to_dir: str, branch: Optional[str] = None):
+    def git_clone(self, repo: str, to_dir: Pathlike, branch: Optional[str] = None):
         """retrieve git clone of repo"""
         if branch:
           self.shellcmd(f"git clone -b {branch} --depth=1 {repo} {to_dir}")
@@ -794,7 +794,9 @@ class CMakeBuilder:
                 self.check(self.options.name)  # check python syntax
 
             if self.options.modified:
-                most_recent_test = pathlib.Path(self.get_most_recent_test()).stem
+                test = self.get_most_recent_test()
+                assert test, "test required"
+                most_recent_test = pathlib.Path(test).stem
                 bld_options.append(f"--target {most_recent_test}")
                 tst_options.append(f"--tests-regex {most_recent_test}")
 

--- a/shedskin/config.py
+++ b/shedskin/config.py
@@ -3,18 +3,19 @@
 Copyright 2005-2023 Mark Dufour and contributors; License GNU GPL version 3 (See LICENSE)
 
 """
+import argparse
 import os
 import sys
 import pathlib
 
 from typing import TYPE_CHECKING, Optional
 if TYPE_CHECKING:
-    import argparse
     from . import python
 
 
 class GlobalInfo:  # XXX add comments, split up
-    def __init__(self):
+    def __init__(self, options: argparse.Namespace):
+        self.options = options
         self.constraints = set()
         self.allvars = set()
         self.allfuncs = set()
@@ -30,7 +31,6 @@ class GlobalInfo:  # XXX add comments, split up
         self.main_module: Optional['python.Module'] = None
         self.module = None
         self.module_path: Optional[pathlib.Path] = None
-        self.options: Optional['argparse.Namespace'] = None
         self.cwd = pathlib.Path.cwd()
         self.builtins: list[str] = [
             "none",

--- a/shedskin/extmod.py
+++ b/shedskin/extmod.py
@@ -198,18 +198,7 @@ class ExtensionModule:
             and infer.called(cl.funcs[name])
         )
 
-    def do_add_globals(self, classes, __ss_mod):
-        """
-        Does add globals.
-
-        :param      classes:   The classes
-        :type       classes:   { type_description }
-        :param      __ss_mod:  The ss modifier
-        :type       __ss_mod:  { type_description }
-
-        :returns:   { description_of_the_return_value }
-        :rtype:     { return_type_description }
-        """
+    def do_add_globals(self, classes, ssmod):
 
         # global variables
         for var in self.supported_vars(self.gv.mv.globals.values()):
@@ -226,7 +215,7 @@ class ExtensionModule:
                         + self.gv.module.ident
                         + "__::"
                         + self.gv.cpp_name(var),
-                        "ssmod": __ss_mod,
+                        "ssmod": ssmod,
                     }
                 )
             else:
@@ -238,7 +227,7 @@ class ExtensionModule:
                         + self.gv.module.ident
                         + "__::"
                         + self.gv.cpp_name(var),
-                        "ssmod": __ss_mod,
+                        "ssmod": ssmod,
                     }
                 )
 

--- a/shedskin/makefile.py
+++ b/shedskin/makefile.py
@@ -106,6 +106,7 @@ def generate_makefile(gx):
     else:
         flags = gx.shedskin_flags / "FLAGS"
 
+    line = ''
     for line in open(flags):
         line = line[:-1]
 

--- a/shedskin/python.py
+++ b/shedskin/python.py
@@ -50,11 +50,11 @@ class Module(PyObject):
     """
 
     def __init__(
-            self, 
-            name: str, 
-            filename: str, 
-            relative_filename: str, 
-            builtin: bool, 
+            self,
+            name: str,
+            filename: str,
+            relative_filename: str,
+            builtin: bool,
             node):
         # set name and its dependent fields
         self.name = name
@@ -121,6 +121,7 @@ class Class(PyObject):
         self.gx.class_def_order += 1
         self.module: Optional[Module] = None # from graph.py:635
         self.parent: Optional['StaticClass'] = None # issues/479
+        self.lcpcount: int = 0
 
     def ancestors(self, inclusive: bool = False):  # XXX attribute (faster)
         a = set(self.bases)

--- a/shedskin/resources/cmake/fn_add_shedskin_product.cmake
+++ b/shedskin/resources/cmake/fn_add_shedskin_product.cmake
@@ -2,7 +2,7 @@ set(__doc__ [[
 
     containing folder_name:
         default: cmake_path(GET CMAKE_CURRENT_SOURCE_DIR STEM name)
-        else: can be overriden by setting SHEDSKIN_NAME 
+        else: can be overriden by setting SHEDSKIN_NAME
 
     <main>.py: can be one of two cases:
         - <containing_folder>/<main>.py
@@ -30,7 +30,7 @@ function(add_shedskin_product)
         MAIN_MODULE
         EXTRA_LIB_DIR
     )
-    set(multiValueArgs 
+    set(multiValueArgs
         SYS_MODULES
         APP_MODULES
         DATA
@@ -62,11 +62,11 @@ function(add_shedskin_product)
         set(BUILD_EXTENSION OFF)
     endif()
 
-    if (DISABLE_EXECUTABLES) 
+    if (DISABLE_EXECUTABLES)
         set(BUILD_EXECUTABLE OFF)
     endif()
 
-    if (DISABLE_EXTENSIONS) 
+    if (DISABLE_EXTENSIONS)
         set(BUILD_EXTENSION OFF)
     endif()
 
@@ -125,7 +125,7 @@ function(add_shedskin_product)
     # module-specific cases
     set(IMPORTS_OS_MODULE OFF)
     set(IMPORTS_RE_MODULE OFF)
- 
+
     # if ${name} starts_with test_ then set IS_TEST to ON
     string(FIND "${name}" "test_" index)
     if("${index}" EQUAL 0)
@@ -153,7 +153,7 @@ function(add_shedskin_product)
             SHEDSKIN_NAME
             SHEDSKIN_MAIN_MODULE
             SHEDSKIN_EXTRA_LIB_DIR
-            
+
             # multi value args
             SHEDSKIN_SYS_MODULES
             SHEDSKIN_APP_MODULES
@@ -190,7 +190,7 @@ function(add_shedskin_product)
         if(mod STREQUAL "os")
             set(IMPORTS_OS_MODULE ON)
             list(APPEND sys_module_list "${SHEDSKIN_LIB}/os/__init__.cpp")
-            list(APPEND sys_module_list "${SHEDSKIN_LIB}/os/__init__.hpp")            
+            list(APPEND sys_module_list "${SHEDSKIN_LIB}/os/__init__.hpp")
         elseif(mod STREQUAL "os.path")
             list(APPEND sys_module_list "${SHEDSKIN_LIB}/os/path.cpp")
             list(APPEND sys_module_list "${SHEDSKIN_LIB}/os/path.hpp")
@@ -232,7 +232,7 @@ function(add_shedskin_product)
             ${SPM_LIB_DIRS}/${LIBGCCPP}
             # $<$<PLATFORM_ID:Windows>:${SPM_LIB_DIRS}/atomic_ops.lib>
             # $<$<PLATFORM_ID:Windows>:${SPM_LIB_DIRS}/atomic_ops_gpl.lib>
-            $<$<BOOL:${IMPORTS_RE_MODULE}>:${SPM_LIB_DIRS}/${LIBPCRE}>            
+            $<$<BOOL:${IMPORTS_RE_MODULE}>:${SPM_LIB_DIRS}/${LIBPCRE}>
         )
         set(LIB_DIRS ${SPM_LIB_DIRS})
         set(LIB_INCLUDES ${SPM_INCLUDE_DIRS})
@@ -251,7 +251,7 @@ function(add_shedskin_product)
             ${BDWgc_INCLUDE_DIRS}
             ${PCRE_INCLUDE_DIRS}
         )
-    else() 
+    else()
         # adding -lutil for every use of os is not a good idea should only be temporary
         # better to just add it on demand if the two relevant pty functions are used
         set(local_prefix "/usr/local")
@@ -269,7 +269,7 @@ function(add_shedskin_product)
         set(local_include "${local_prefix}/include")
         set(local_libdir "${local_prefix}/lib")
 
-        set(LIB_DEPS 
+        set(LIB_DEPS
             "-lgc"
             "-lgccpp"
             "$<$<BOOL:${IMPORTS_RE_MODULE}>:-lpcre>"
@@ -280,8 +280,8 @@ function(add_shedskin_product)
             ${local_libdir}
             ${SHEDSKIN_LINK_DIRS}
         )
-        set(LIB_INCLUDES 
-            ${local_include}            
+        set(LIB_INCLUDES
+            ${local_include}
             ${SHEDSKIN_INCLUDE_DIRS}
         )
     endif()
@@ -313,7 +313,7 @@ function(add_shedskin_product)
 
         foreach(mod ${app_modules})
             list(APPEND translated_files "${PROJECT_EXE_DIR}/${mod}.cpp")
-            list(APPEND translated_files "${PROJECT_EXE_DIR}/${mod}.hpp")            
+            list(APPEND translated_files "${PROJECT_EXE_DIR}/${mod}.hpp")
         endforeach()
 
 
@@ -324,7 +324,7 @@ function(add_shedskin_product)
                 DEPENDS "${SHEDSKIN_MAIN_MODULE}"
                 COMMENT "translating ${main_py} to exe"
                 VERBATIM
-            )        
+            )
         else()
             add_custom_command(OUTPUT ${translated_files}
                 COMMAND shedskin translate --nomakefile -o ${PROJECT_EXE_DIR} ${opts} "${main_py}"
@@ -348,7 +348,7 @@ function(add_shedskin_product)
 
         # for testing only genexpr complex cases
         # add_custom_command(TARGET ${EXE} POST_BUILD
-        #     COMMAND ${CMAKE_COMMAND} -E echo 
+        #     COMMAND ${CMAKE_COMMAND} -E echo
         #     "enable-warnings = $<$<AND:${UNIX},$<BOOL:${ENABLE_WARNINGS}>>:-Wall>"
         # )
 
@@ -394,6 +394,7 @@ function(add_shedskin_product)
 
         target_link_options(${EXE} PRIVATE
             ${SHEDSKIN_LINK_OPTIONS}
+            "$<$<BOOL:${APPLE}>:-Wl,-ld_classic>"
         )
 
         target_link_directories(${EXE} PRIVATE
@@ -437,7 +438,7 @@ function(add_shedskin_product)
 
         foreach(mod ${app_modules})
             list(APPEND translated_files "${PROJECT_EXT_DIR}/${mod}.cpp")
-            list(APPEND translated_files "${PROJECT_EXT_DIR}/${mod}.hpp")            
+            list(APPEND translated_files "${PROJECT_EXT_DIR}/${mod}.hpp")
         endforeach()
 
 
@@ -448,7 +449,7 @@ function(add_shedskin_product)
                 DEPENDS "${SHEDSKIN_MAIN_MODULE}"
                 COMMENT "translating ${main_py} to ext"
                 VERBATIM
-            )        
+            )
         else()
             add_custom_command(OUTPUT ${translated_files}
                 COMMAND shedskin translate --nomakefile -o ${PROJECT_EXT_DIR} -e ${opts} "${main_py}"
@@ -523,6 +524,7 @@ function(add_shedskin_product)
             # "-fno-common" # can be excluded because it is already the default
             "-dynamic" # can be excluded because it is already the default
             ${SHEDSKIN_LINK_OPTIONS}
+            "$<$<BOOL:${APPLE}>:-Wl,-ld_classic>"
         )
 
         target_link_libraries(${EXT} PRIVATE

--- a/shedskin/typestr.py
+++ b/shedskin/typestr.py
@@ -182,6 +182,7 @@ def typestr(
             mv=mv,
         )
     except RuntimeError:
+        assert mv
         if (
             not mv.module.builtin
             and isinstance(node, python.Variable)
@@ -401,6 +402,7 @@ def typestrnew(
 
     # --- namespace prefix
     namespace = ""
+    assert mv
     if cl.module not in [mv.module, gx.modules["builtin"]]:
         if cplusplus:
             namespace = cl.module.full_path() + "::"


### PR DESCRIPTION
- `GlobalInfo` class now takes an argparse.Namespace param.. This was optional before but there's no point since this is used everywhere.

- fixes link warnings on APPLE:
```
ld: warning: REFERENCED_DYNAMICALLY flag on symbol '_catch_exception_raise' is deprecated
ld: warning: REFERENCED_DYNAMICALLY flag on symbol '_catch_exception_raise_state' is deprecated
ld: warning: REFERENCED_DYNAMICALLY flag on symbol '_catch_exception_raise_state_identity' is deprecated
```

- fix a number of type related warnings
