### PR TITLE
Includes bug fix for --spm build

### DIFF
--- a/shedskin/cmake.py
+++ b/shedskin/cmake.py
@@ -267,12 +267,12 @@ class ShedskinDependencyManager:
         bdwgc_build = bdwgc_src / "build"
 
         print("download / build / install bdwgc")
-        self.git_clone(bdwgc_repo, bdwgc_src)
+        self.git_clone(bdwgc_repo, bdwgc_src, branch="v8.2.6")
         if platform.system() == "Windows":
             # windows needs libatomic_ops
             libatomic_repo = "https://github.com/ivmai/libatomic_ops.git"
             libatomic_src = bdwgc_src / "libatomic_ops"
-            self.git_clone(libatomic_repo, libatomic_src)
+            self.git_clone(libatomic_repo, libatomic_src, branch="v7.8.2")
         bdwgc_build.mkdir(exist_ok=True)
         self.cmake_generate(
             bdwgc_src,

--- a/shedskin/config.py
+++ b/shedskin/config.py
@@ -6,10 +6,11 @@ Copyright 2005-2023 Mark Dufour and contributors; License GNU GPL version 3 (See
 import argparse
 import os
 import sys
-import pathlib
+from pathlib import Path
 
 from typing import TYPE_CHECKING, Optional
 if TYPE_CHECKING:
+    from . import infer
     from . import python
     from .utils import ProgressBar
 
@@ -17,22 +18,22 @@ if TYPE_CHECKING:
 class GlobalInfo:  # XXX add comments, split up
     def __init__(self, options: argparse.Namespace):
         self.options = options
-        self.constraints = set()
-        self.allvars = set()
-        self.allfuncs = set()
-        self.allclasses = set()
+        self.constraints: set[tuple['infer.CNode', 'infer.CNode']] = set()
+        self.allvars: set['python.Variable'] = set()
+        self.allfuncs: set['python.Function'] = set()
+        self.allclasses: set['python.Class'] = set()
         self.cnode = {}
         self.types = {}
-        self.templates = 0
-        self.modules = {}
+        self.templates: int = 0
+        self.modules: dict[str, 'python.Module'] = {}
         self.inheritance_relations = {}
         self.inheritance_temp_vars = {}
         self.parent_nodes = {}
         self.inherited = set()
         self.main_module: Optional['python.Module'] = None
-        self.module = None
-        self.module_path: Optional[pathlib.Path] = None
-        self.cwd = pathlib.Path.cwd()
+        self.module: Optional['python.Module'] = None
+        self.module_path: Optional[Path] = None
+        self.cwd: Path = Path.cwd()
         self.builtins: list[str] = [
             "none",
             "str_",
@@ -116,11 +117,11 @@ class GlobalInfo:  # XXX add comments, split up
                 shedskin_directory = os.path.join(dirname, shedskin_directory)
                 break
         shedskin_libdir = os.path.join(shedskin_directory, "lib")
-        self.shedskin_lib = pathlib.Path(shedskin_libdir)
+        self.shedskin_lib = Path(shedskin_libdir)
         system_libdir = "/usr/share/shedskin/lib"
         self.sysdir = shedskin_directory
         # set resources subdirectors
-        self.shedskin_resources = pathlib.Path(shedskin_directory) / "resources"
+        self.shedskin_resources = Path(shedskin_directory) / "resources"
         self.shedskin_cmake = self.shedskin_resources / "cmake" / "modular"
         self.shedskin_conan = self.shedskin_resources / "conan"
         self.shedskin_flags = self.shedskin_resources / "flags"

--- a/shedskin/python.py
+++ b/shedskin/python.py
@@ -435,8 +435,9 @@ def lookup_module(node, mv: 'graph.ModuleVisitor'):
 
 
 def def_class(gx: 'config.GlobalInfo', name: str, mv: Optional['graph.ModuleVisitor'] = None):
-    if mv is None:
+    if not mv:
         mv = gx.modules["builtin"].mv
+    assert mv
     if name in mv.classes:
         return mv.classes[name]
     elif name in mv.ext_classes:

--- a/shedskin/python.py
+++ b/shedskin/python.py
@@ -76,15 +76,15 @@ class Module(PyObject):
     def full_path(self) -> str:
         return "__" + "__::__".join(self.name_list) + "__"
 
-    def include_path(self):
+    def include_path(self) -> str:
         if self.relative_filename.name.endswith("__init__.py"):
             return os.path.join(self.relative_path, "__init__.hpp")
         else:
             filename_without_ext = os.path.splitext(self.relative_filename)[0]
             return filename_without_ext + ".hpp"
 
-    def in_globals(self, ident: str):
-        assert self.mv, "must be graph.ModuleVisitor instance"
+    def in_globals(self, ident: str) -> bool:
+        assert self.mv, "must have graph.ModuleVisitor instance"
         return (
                ident in self.mv.globals
             or ident in self.mv.funcs


### PR DESCRIPTION
--spm build option uses git to clone dependencies and then builds them the standard user cache directory.. The problem is that the prior implementation didn't fix the branch or tag of each dependency  during cloning. If one of the deps changed, it broke the --spm build option which is what happened with bdwgc. 

This PR includes fixes to address the above issue.