### PR TITLE
ruff format / check cleanups

### DIFF
--- a/shedskin/ast_utils.py
+++ b/shedskin/ast_utils.py
@@ -5,6 +5,7 @@
 This module provides utility functions and classes for working with abstract syntax
 trees (ASTs) in Python.
 """
+
 import ast
 
 from typing import List, Tuple, Union, Any
@@ -31,9 +32,10 @@ def is_constant(node: ast.AST) -> bool:
     """Check if a node is a constant"""
     return isinstance(node, ast.Constant)
 
+
 def is_none(node: ast.AST) -> bool:
     """Check if a node is the None constant"""
-    if (isinstance(node, ast.Name) and node.id == "None"):
+    if isinstance(node, ast.Name) and node.id == "None":
         return True
     else:
         if isinstance(node, ast.Constant) and node.value is None:
@@ -80,12 +82,11 @@ def is_zip2(node: Union[ast.For, ast.comprehension]) -> bool:
         and is_assign_list_or_tuple(node.target)
     )
 
+
 # --- recursively determine (lvalue, rvalue) pairs in assignment expressions
 def assign_rec(left: ast.AST, right: ast.AST) -> List[Tuple[ast.AST, ast.AST]]:
     """Recursively determine (lvalue, rvalue) pairs in assignment expressions"""
-    if is_assign_list_or_tuple(left) and isinstance(
-        right, (ast.Tuple, ast.List)
-    ):
+    if is_assign_list_or_tuple(left) and isinstance(right, (ast.Tuple, ast.List)):
         assert isinstance(left, (ast.Tuple, ast.List))
         pairs = []
         for lvalue, rvalue in zip(left.elts, right.elts):
@@ -95,7 +96,7 @@ def assign_rec(left: ast.AST, right: ast.AST) -> List[Tuple[ast.AST, ast.AST]]:
         return [(left, right)]
 
 
-def aug_msg(gx: 'config.GlobalInfo', node: ast.BinOp, msg: str) -> str:
+def aug_msg(gx: "config.GlobalInfo", node: ast.BinOp, msg: str) -> str:
     """Generate an augmented assignment message"""
     if node in gx.augment:
         return "__i" + msg + "__"
@@ -103,8 +104,7 @@ def aug_msg(gx: 'config.GlobalInfo', node: ast.BinOp, msg: str) -> str:
 
 
 class BaseNodeVisitor:
-    """
-    Copy of ast.NodeVisitor with added *args argument to visit functions
+    """Copy of ast.NodeVisitor with added *args argument to visit functions
 
     A node visitor base class that walks the abstract syntax tree and calls a
     visitor function for every node found.  This function may return a value
@@ -122,9 +122,9 @@ class BaseNodeVisitor:
 
     def visit(self, node: ast.AST, *args: Any) -> None:
         """Visit a node."""
-        assert isinstance(
-            node, ast.AST
-        ), "Expected node of type ast.AST, got node of type %s" % type(node)
+        assert isinstance(node, ast.AST), (
+            "Expected node of type ast.AST, got node of type %s" % type(node)
+        )
         method = "visit_" + node.__class__.__name__
         visitor = getattr(self, method, None)
         if visitor:

--- a/shedskin/cmake.py
+++ b/shedskin/cmake.py
@@ -42,31 +42,34 @@ from .utils import CYAN, GREEN, RED, RESET, WHITE
 # type alias
 Pathlike = Union[pathlib.Path, str]
 
+
 def get_pkg_path() -> pathlib.Path:
     """Return the path to the shedskin package"""
     _pkg_path = pathlib.Path(__file__).parent
     assert _pkg_path.name == "shedskin"
     return _pkg_path
 
+
 def pkg_path() -> None:
     """Used by cmake to get the shedskin package path automatically"""
     sys.stdout.write(str(get_pkg_path()))
+
 
 def get_user_cache_dir() -> pathlib.Path:
     """Get user cache directory depending on platform"""
     system = platform.system()
     if system == "Darwin":
         return pathlib.Path("~/Library/Caches/shedskin").expanduser()
-    elif system == "Linux":
+    if system == "Linux":
         return pathlib.Path("~/.cache/shedskin").expanduser()
-    elif system == "Windows":
+    if system == "Windows":
         profile = os.getenv("USERPROFILE")
         if not profile:
-            raise SystemExit(f"USERPROFILE environment variable not set on windows")
+            raise SystemExit("USERPROFILE environment variable not set on windows")
         user_dir = pathlib.Path(profile)
-        return user_dir / 'AppData' / 'Local' / 'shedskin' / 'Cache'
-    else:
-        raise SystemExit(f"{system} os not supported")
+        return user_dir / "AppData" / "Local" / "shedskin" / "Cache"
+    raise SystemExit(f"{system} os not supported")
+
 
 def user_cache_dir() -> None:
     """Used by CMakeLists.txt execute process"""
@@ -79,7 +82,7 @@ class ConanBDWGC:
     def __init__(
         self,
         name: str = "bdwgc",
-        version: str  = "8.2.2",
+        version: str = "8.2.2",
         cplusplus: bool = True,
         cord: bool = False,
         gcj_support: bool = False,
@@ -104,12 +107,12 @@ class ConanPCRE:
     def __init__(
         self,
         name: str = "pcre",
-        version: str ="8.45",
+        version: str = "8.45",
         build_pcrecpp: bool = True,
-        build_pcregrep: bool =False,
-        shared: bool =False,
-        with_bzip2: bool =False,
-        with_zlib: bool =False,
+        build_pcregrep: bool = False,
+        shared: bool = False,
+        with_bzip2: bool = False,
+        with_zlib: bool = False,
     ):
         self.name = name
         self.version = version
@@ -121,6 +124,7 @@ class ConanPCRE:
 
     def __str__(self) -> str:
         return f"{self.name}/{self.version}"
+
 
 class ConanDependencyManager:
     """Dependency manager which manages and installs all conan dependencies"""
@@ -192,16 +196,20 @@ class ShedskinDependencyManager:
         """Run a shell command"""
         print("-" * 80)
         print(f"{WHITE}cmd{RESET}: {CYAN}{cmd}{RESET}")
-        os.system(cmd) #.format(*args, **kwds))
+        os.system(cmd)  # .format(*args, **kwds))
 
-    def git_clone(self, repo: str, to_dir: Pathlike, branch: Optional[str] = None) -> None:
+    def git_clone(
+        self, repo: str, to_dir: Pathlike, branch: Optional[str] = None
+    ) -> None:
         """Retrieve a git clone of a repository"""
         if branch:
-          self.shellcmd(f"git clone -b {branch} --depth=1 {repo} {to_dir}")
+            self.shellcmd(f"git clone -b {branch} --depth=1 {repo} {to_dir}")
         else:
-           self.shellcmd(f"git clone --depth=1 {repo} {to_dir}")
+            self.shellcmd(f"git clone --depth=1 {repo} {to_dir}")
 
-    def cmake_generate(self, src_dir: Pathlike, build_dir: Pathlike, prefix: Pathlike, **options: bool) -> None:
+    def cmake_generate(
+        self, src_dir: Pathlike, build_dir: Pathlike, prefix: Pathlike, **options: bool
+    ) -> None:
         """Activate cmake configuration / generation stage"""
         opts = " ".join(f"-D{k}={v}" for k, v in options.items())
         self.shellcmd(
@@ -329,8 +337,8 @@ class ShedskinDependencyManager:
     def install_pcre(self) -> None:
         """Download / build / install pcre"""
         pcre_repo = "https://github.com/luvit/pcre.git"
-        pcre_src = self.src_dir / 'pcre'
-        pcre_build =  pcre_src / "build"
+        pcre_src = self.src_dir / "pcre"
+        pcre_build = pcre_src / "build"
         print("download / build / install pcre")
         self.git_clone(pcre_repo, pcre_src)
         pcre_build.mkdir(parents=True, exist_ok=True)
@@ -350,6 +358,7 @@ class ShedskinDependencyManager:
         )
         self.cmake_build(pcre_build)
         self.cmake_install(pcre_build)
+
 
 def add_shedskin_product(
     main_module: Optional[str] = None,
@@ -400,7 +409,7 @@ def add_shedskin_product(
     """
 
     if extra_lib_dir:
-        cmdline_options = '-X' + extra_lib_dir
+        cmdline_options = "-X" + extra_lib_dir
         include_dirs = [extra_lib_dir]
 
     def mk_add(lines: list[str], spaces: int = 4) -> Callable[[int, str], None]:
@@ -496,10 +505,12 @@ def get_cmakefile_template(**kwds: str) -> str:
     tmpl = cmakelists_tmpl.read_text()
     return tmpl % kwds
 
+
 def check_cmake_availability() -> None:
     """Check if cmake executable is available in path"""
-    if not bool(shutil.which('cmake')):
-        raise Exception("cmake not available in path")
+    if not bool(shutil.which("cmake")):
+        raise RuntimeError("cmake not available in path")
+
 
 def generate_cmakefile(gx: config.GlobalInfo) -> None:
     """Improved generator using built-in machinery"""
@@ -536,7 +547,7 @@ def generate_cmakefile(gx: config.GlobalInfo) -> None:
         compile_options.append("-D__SS_BACKTRACE -rdynamic -fno-inline")
     if gx.nogc:
         compile_options.append("-D__SS_NOGC")
-    compile_opts = ' '.join(compile_options)
+    compile_opts = " ".join(compile_options)
 
     for module in modules:
         if module.builtin and module.filename.is_relative_to(gx.shedskin_lib):
@@ -644,7 +655,7 @@ class CMakeBuilder:
             print("*** test:", test)
             try:
                 checks = []
-                with open(test, encoding='utf8') as fopen:
+                with open(test, encoding="utf8") as fopen:
                     for line in fopen:
                         if line.startswith("#*"):
                             checks.append(line[1:].strip())
@@ -693,7 +704,7 @@ class CMakeBuilder:
     def cmake_test(self, options: list[str]) -> None:
         """Activate ctest"""
         opts = " ".join(options)
-        if platform.system() == 'Windows':
+        if platform.system() == "Windows":
             cfg = f"-C {self.options.build_type}"
         else:
             cfg = ""
@@ -714,7 +725,11 @@ class CMakeBuilder:
         """Process a shedskin program with cmake"""
         start_time = time.time()
 
-        cfg_options = [] if not getattr(self.options, 'cfg', None) else [f'-D{opt}' for opt in self.options.cfg]
+        cfg_options = (
+            []
+            if not getattr(self.options, "cfg", None)
+            else [f"-D{opt}" for opt in self.options.cfg]
+        )
         bld_options = []
         tst_options = []
 
@@ -725,11 +740,11 @@ class CMakeBuilder:
         if self.options.extmod:
             cfg_options.append("-DBUILD_EXTENSION=ON")
 
-        if hasattr(self.options, 'disable_exes'):
+        if hasattr(self.options, "disable_exes"):
             if self.options.disable_exes:
                 cfg_options.append("-DDISABLE_EXECUTABLES=ON")
 
-        if hasattr(self.options, 'disable_exts'):
+        if hasattr(self.options, "disable_exts"):
             if self.options.disable_exts:
                 cfg_options.append("-DDISABLE_EXTENSIONS=ON")
 
@@ -809,12 +824,7 @@ class CMakeBuilder:
             # nocleanup
 
             if self.options.pytest:
-                try:
-                    import pytest
-
-                    os.system("pytest")
-                except ImportError:
-                    self.log.exception("pytest not found")
+                os.system("pytest")
 
             if self.options.run:
                 target_suffix = "-exe"
@@ -855,7 +865,6 @@ class CMakeBuilder:
                 print(failures)
         else:
             raise ValueError("option.run_errs not set")
-            sys.exit()
 
         end_time = time.time()
         elapsed_time = time.strftime("%H:%M:%S", time.gmtime(end_time - start_time))

--- a/shedskin/config.py
+++ b/shedskin/config.py
@@ -4,40 +4,48 @@
 
 `GlobalInfo` which is referred to in shedskin as `gx`.
 """
+
 import argparse
 import os
 import sys
 from pathlib import Path
 
 from typing import TYPE_CHECKING, Optional, Any, Tuple, List, Union, TypeAlias
+
 if TYPE_CHECKING:
     import ast
     from . import infer
     from . import python
     from .utils import ProgressBar
 
-CartesianProduct: TypeAlias = Tuple[Tuple['python.Class', int] , ...]
+CartesianProduct: TypeAlias = Tuple[Tuple["python.Class", int], ...]
 
 
 class GlobalInfo:  # XXX add comments, split up
     """Global configuration and state for the shedskin compiler"""
+
     def __init__(self, options: argparse.Namespace):
         self.options = options
-        self.constraints: set[tuple['infer.CNode', 'infer.CNode']] = set()
-        self.allvars: set['python.Variable'] = set()
-        self.allfuncs: set['python.Function'] = set()
-        self.allclasses: set['python.Class'] = set()
-        self.cnode: dict[Tuple[Any, int, int], 'infer.CNode']  = {}
-        self.types: dict['infer.CNode', set[Tuple[Any, int]]] = {}
-        self.orig_types: dict['infer.CNode', set[Tuple[Any, int]]] = {}
+        self.constraints: set[tuple["infer.CNode", "infer.CNode"]] = set()
+        self.allvars: set["python.Variable"] = set()
+        self.allfuncs: set["python.Function"] = set()
+        self.allclasses: set["python.Class"] = set()
+        self.cnode: dict[Tuple[Any, int, int], "infer.CNode"] = {}
+        self.types: dict["infer.CNode", set[Tuple[Any, int]]] = {}
+        self.orig_types: dict["infer.CNode", set[Tuple[Any, int]]] = {}
         self.templates: int = 0
-        self.modules: dict[str, 'python.Module'] = {}
-        self.inheritance_relations: dict[Union['python.Function', 'ast.AST'], List[Union['python.Function', 'ast.AST']]] = {}
-        self.inheritance_temp_vars: dict['python.Variable', List['python.Variable']] = {}
+        self.modules: dict[str, "python.Module"] = {}
+        self.inheritance_relations: dict[
+            Union["python.Function", "ast.AST"],
+            List[Union["python.Function", "ast.AST"]],
+        ] = {}
+        self.inheritance_temp_vars: dict[
+            "python.Variable", List["python.Variable"]
+        ] = {}
         self.parent_nodes: dict[ast.AST, ast.AST] = {}
         self.inherited: set[ast.AST] = set()
-        self.main_module: 'python.Module'
-        self.module: Optional['python.Module'] = None
+        self.main_module: "python.Module"
+        self.module: Optional["python.Module"] = None
         self.module_path: Optional[Path] = None
         self.cwd: Path = Path.cwd()
         self.builtins: list[str] = [
@@ -58,20 +66,24 @@ class GlobalInfo:  # XXX add comments, split up
         # instance node for instance Variable assignment
         self.assign_target: dict[ast.AST, ast.AST] = {}
         # allocation site type information across iterations
-        self.alloc_info: dict[Tuple[str, CartesianProduct, ast.AST], Tuple['python.Class', int]] = {}
-        self.new_alloc_info: dict[Tuple[str, CartesianProduct, ast.AST], Tuple['python.Class', int]] = {}
+        self.alloc_info: dict[
+            Tuple[str, CartesianProduct, ast.AST], Tuple["python.Class", int]
+        ] = {}
+        self.new_alloc_info: dict[
+            Tuple[str, CartesianProduct, ast.AST], Tuple["python.Class", int]
+        ] = {}
         self.iterations: int = 0
         self.total_iterations: int = 0
         self.lambdawrapper: dict[Any, str] = {}
         self.init_directories()
-        illegal_file = open(self.shedskin_illegal /  "illegal.txt")
+        illegal_file = open(self.shedskin_illegal / "illegal.txt")
         self.cpp_keywords = set(line.strip() for line in illegal_file)
         self.ss_prefix: str = "__ss_"
         self.list_types: dict[Tuple[int, ast.AST], int] = {}
         self.loopstack: List[Union[ast.While, ast.For]] = []  # track nested loops
-#        self.comments = {}  # TODO not filled anymore?
+        #        self.comments = {}  # TODO not filled anymore?
         self.import_order: int = 0  # module import order
-        self.from_module: dict[ast.AST, 'python.Module'] = {}
+        self.from_module: dict[ast.AST, "python.Module"] = {}
         self.class_def_order: int = 0
         # command-line options
         self.wrap_around_check: bool = True
@@ -99,19 +111,21 @@ class GlobalInfo:  # XXX add comments, split up
         self.bool_test_only: set[ast.AST] = set()
         self.called: set[ast.Attribute] = set()
         self.tempcount: dict[Any, str] = {}
-        self.struct_unpack: dict[ast.Assign, Tuple[List[Tuple[str, str, str, int]], str, str]] = {}
+        self.struct_unpack: dict[
+            ast.Assign, Tuple[List[Tuple[str, str, str, int]], str, str]
+        ] = {}
         self.augment: set[ast.AST] = set()
 
         self.maxhits = 0  # XXX amaze.py termination
         self.terminal = None
-        self.progressbar:  Optional['ProgressBar'] = None
+        self.progressbar: Optional["ProgressBar"] = None
         self.generate_cmakefile: bool = False
 
         # from infer.py
         self.added_allocs: int = 0
         self.added_allocs_set: set[Any] = set()
         self.added_funcs: int = 0
-        self.added_funcs_set: set['python.Function'] = set()
+        self.added_funcs_set: set["python.Function"] = set()
         self.cpa_clean: bool = False
         self.cpa_limit: int = 0
         self.cpa_limited: bool = False
@@ -119,7 +133,7 @@ class GlobalInfo:  # XXX add comments, split up
 
     def init_directories(self) -> None:
         """Initialize directory paths"""
-        abspath = os.path.abspath(__file__) # sanitize mixed fwd/bwd slashes (mingw)
+        abspath = os.path.abspath(__file__)  # sanitize mixed fwd/bwd slashes (mingw)
         shedskin_directory = os.sep.join(abspath.split(os.sep)[:-1])
         for dirname in sys.path:
             if os.path.exists(os.path.join(dirname, shedskin_directory)):

--- a/shedskin/error.py
+++ b/shedskin/error.py
@@ -2,12 +2,12 @@
 # Copyright 2005-2024 Mark Dufour and contributors; GNU GPL version 3 (See LICENSE)
 """shedskin.error: error handling"""
 
-
 import ast
 import logging
 import sys
 
 from typing import TYPE_CHECKING, Optional, Tuple, Union, TypeAlias
+
 if TYPE_CHECKING:
     from . import config
     from . import graph
@@ -28,10 +28,10 @@ ERRORS: set[Error] = set()
 
 def error(
     msg: str,
-    gx: 'config.GlobalInfo',
-    node: Optional[Union[ast.AST, 'python.Variable']] = None,
-    warning: bool=False,
-    mv: Optional['graph.ModuleVisitor']=None,
+    gx: "config.GlobalInfo",
+    node: Optional[Union[ast.AST, "python.Variable"]] = None,
+    warning: bool = False,
+    mv: Optional["graph.ModuleVisitor"] = None,
 ) -> None:
     """Report an error"""
     from . import infer
@@ -45,9 +45,9 @@ def error(
     filename = lineno = None
     if mv:
         filename = mv.module.relative_filename
-        if isinstance(node, ast.AST) and hasattr(node, 'lineno'):
+        if isinstance(node, ast.AST) and hasattr(node, "lineno"):
             lineno = node.lineno
-    result = (kind, str(filename or ''), lineno, msg)
+    result = (kind, str(filename or ""), lineno, msg)
     if result not in ERRORS:
         ERRORS.add(result)
     if not warning:

--- a/shedskin/extmod.py
+++ b/shedskin/extmod.py
@@ -18,6 +18,7 @@ garbage collected after the (wrapper) reference count drops to 0 on the
 CPython side.
 
 """
+
 import logging
 
 from . import infer
@@ -25,7 +26,8 @@ from . import python
 from . import typestr
 
 
-from typing import TYPE_CHECKING, Optional, Union, List, Iterable
+from typing import TYPE_CHECKING, Optional, List, Iterable
+
 if TYPE_CHECKING:
     from . import config
     from . import cpp
@@ -43,7 +45,7 @@ OVERLOAD = [
 ] + OVERLOAD_SINGLE
 
 
-def clname(cl: 'python.Class') -> str:
+def clname(cl: "python.Class") -> str:
     """Class name normalizer"""
     return "__ss_%s_%s" % ("_".join(cl.mv.module.name_list), cl.ident)
 
@@ -51,7 +53,7 @@ def clname(cl: 'python.Class') -> str:
 class ExtensionModule:
     """Extension module generator"""
 
-    def __init__(self, gx: 'config.GlobalInfo', gv: 'cpp.GenerateVisitor'):
+    def __init__(self, gx: "config.GlobalInfo", gv: "cpp.GenerateVisitor"):
         self.gx = gx
         self.gv = gv
 
@@ -68,7 +70,9 @@ class ExtensionModule:
                     % (module.full_path(), what, "_".join(module.name_list))
                 )
 
-    def supported_vars(self, variables: Iterable['python.Variable']) -> List['python.Variable']: # XXX virtuals?
+    def supported_vars(
+        self, variables: Iterable["python.Variable"]
+    ) -> List["python.Variable"]:  # XXX virtuals?
         """Supported variables
         XXX currently only classs / instance variables"""
         supported = []
@@ -100,7 +104,9 @@ class ExtensionModule:
             supported.append(var)
         return supported
 
-    def supported_funcs(self, funcs: Iterable['python.Function']) -> List['python.Function']:
+    def supported_funcs(
+        self, funcs: Iterable["python.Function"]
+    ) -> List["python.Function"]:
         """Supported functions"""
         supported = []
         for func in funcs:
@@ -170,7 +176,7 @@ class ExtensionModule:
                     )
         return supported
 
-    def has_method(self, cl: 'python.Class', name: str) -> bool:  # XXX shared.py
+    def has_method(self, cl: "python.Class", name: str) -> bool:  # XXX shared.py
         """Check if a class has a method"""
         return (
             name in cl.funcs
@@ -179,7 +185,7 @@ class ExtensionModule:
             and infer.called(cl.funcs[name])
         )
 
-    def do_add_globals(self, classes: List['python.Class'], ssmod: str) -> None:
+    def do_add_globals(self, classes: List["python.Class"], ssmod: str) -> None:
         """Add global variables to the module"""
         # global variables
         for var in self.supported_vars(self.gv.mv.globals.values()):
@@ -212,7 +218,9 @@ class ExtensionModule:
                     }
                 )
 
-    def do_reduce_setstate(self, cl: 'python.Class', vars: List['python.Variable']) -> None:
+    def do_reduce_setstate(
+        self, cl: "python.Class", vars: List["python.Variable"]
+    ) -> None:
         """Generate a reduce and setstate method"""
         write = self.write
         if python.def_class(self.gx, "Exception") in cl.ancestors():  # XXX
@@ -256,7 +264,7 @@ class ExtensionModule:
         write("    return Py_None;")
         write("}\n")
 
-    def convert_methods(self, cl: 'python.Class', declare: bool) -> None:
+    def convert_methods(self, cl: "python.Class", declare: bool) -> None:
         """Generate converted methods"""
         write = self.write
         if python.def_class(self.gx, "Exception") in cl.ancestors():
@@ -310,7 +318,9 @@ class ExtensionModule:
             )
             write("}\n}")
 
-    def do_extmod_methoddef(self, ident: str, funcs: List['python.Function'], cl: Optional['python.Class']) -> None:
+    def do_extmod_methoddef(
+        self, ident: str, funcs: List["python.Function"], cl: Optional["python.Class"]
+    ) -> None:
         """Generate an extension method definition"""
         write = self.write
         if cl:
@@ -370,7 +380,7 @@ class ExtensionModule:
         # write("    {NULL}\n};\n")
         write("    {NULL, NULL, 0, NULL}\n};\n")
 
-    def do_extmod_method(self, func: 'python.Function') -> None:
+    def do_extmod_method(self, func: "python.Function") -> None:
         """Generate an extension method"""
         write = self.write
         is_method = isinstance(func.parent, python.Class)
@@ -492,11 +502,16 @@ class ExtensionModule:
         # write("        return;\n")
 
         # module init function
-        write("static struct PyModuleDef Module_%s = {" % "_".join(self.gv.module.name_list))
+        write(
+            "static struct PyModuleDef Module_%s = {"
+            % "_".join(self.gv.module.name_list)
+        )
         write("    PyModuleDef_HEAD_INIT,")
         write('    "%s",   /* name of module */' % "_".join(self.gv.module.name_list))
-        write("    NULL,   /* module documentation, may be NULL */") # FIXME
-        write("    -1,     /* size of per-interpreter state of the module or -1 if the module keeps state in global variables. */")
+        write("    NULL,   /* module documentation, may be NULL */")  # FIXME
+        write(
+            "    -1,     /* size of per-interpreter state of the module or -1 if the module keeps state in global variables. */"
+        )
         write("    %s" % "Global_" + "_".join(self.gv.module.name_list) + "Methods")
         write("};")
 
@@ -567,7 +582,7 @@ class ExtensionModule:
         for cl in classes:
             self.convert_methods(cl, False)
 
-    def do_extmod_class(self, cl: 'python.Class') -> None:
+    def do_extmod_class(self, cl: "python.Class") -> None:
         """Generates a python c-api extension type."""
         write = self.write
         for n in cl.module.name_list:
@@ -614,9 +629,7 @@ class ExtensionModule:
             "PyObject *%sNew(PyTypeObject *type, PyObject *args, PyObject *kwargs) {"
             % clname(cl)
         )
-        write(
-            "    (void)args; (void)kwargs;"
-        )
+        write("    (void)args; (void)kwargs;")
         write(
             "    %sObject *self = (%sObject *)type->tp_alloc(type, 0);"
             % (clname(cl), clname(cl))
@@ -645,7 +658,7 @@ class ExtensionModule:
                 "PyObject *__ss_get_%s_%s(%sObject *self, void *closure) {"
                 % (clname(cl), var.name, clname(cl))
             )
-            write("    (void)closure;");
+            write("    (void)closure;")
             write("    return __to_py(self->__ss_object->%s);" % self.gv.cpp_name(var))
             write("}\n")
 
@@ -653,7 +666,7 @@ class ExtensionModule:
                 "int __ss_set_%s_%s(%sObject *self, PyObject *value, void *closure) {"
                 % (clname(cl), var.name, clname(cl))
             )
-            write("    (void)closure;");
+            write("    (void)closure;")
             write("    try {")
             typ = typestr.nodetypestr(self.gx, var, var.parent, mv=self.gv.mv)
             if typ == "void *":  # XXX investigate
@@ -765,6 +778,7 @@ class ExtensionModule:
 
     def convert_methods2(self) -> None:
         """Generate converted methods"""
+
         def write(s: str) -> None:
             return print(s, file=self.gv.out)
 

--- a/shedskin/log.py
+++ b/shedskin/log.py
@@ -1,7 +1,6 @@
 # SHED SKIN Python-to-C++ Compiler
 # Copyright 2005-2024 Mark Dufour and contributors; GNU GPL version 3 (See LICENSE)
-"""shedskin.log: provides logging support
-"""
+"""shedskin.log: provides logging support"""
 
 import logging
 
@@ -12,7 +11,8 @@ from typing import Optional
 
 class ShedskinFormatter(logging.Formatter):
     """Formatter for Shedskin logs"""
-    def __init__(self, datefmt: Optional[str]=None):
+
+    def __init__(self, datefmt: Optional[str] = None):
         self._info_formatter = logging.Formatter(
             utils.MOVE + "%(message)s", datefmt=datefmt
         )
@@ -26,7 +26,6 @@ class ShedskinFormatter(logging.Formatter):
         if record.levelname == "INFO":
             return self._info_formatter.format(record)
         return self._other_formatter.format(record)
-
 
 
 class CustomFormatter(logging.Formatter):
@@ -60,7 +59,7 @@ class CustomFormatter(logging.Formatter):
         return formatter.format(record)
 
 
-def config_log(debug: bool=True) -> None:
+def config_log(debug: bool = True) -> None:
     """Configure the logging system"""
     __handler = logging.StreamHandler()
     __handler.setFormatter(CustomFormatter())

--- a/shedskin/makefile.py
+++ b/shedskin/makefile.py
@@ -1,7 +1,6 @@
 # SHED SKIN Python-to-C++ Compiler
 # Copyright 2005-2024 Mark Dufour and contributors; GNU GPL version 3 (See LICENSE)
-"""shedskin.makefile: makefile generator
-"""
+"""shedskin.makefile: makefile generator"""
 
 import os
 import pathlib
@@ -12,6 +11,7 @@ import sysconfig
 
 # type-checking
 from typing import TYPE_CHECKING, Optional
+
 if TYPE_CHECKING:
     from . import config
 
@@ -24,7 +24,7 @@ def check_output(cmd: str) -> Optional[str]:
         return None
 
 
-def generate_makefile(gx: 'config.GlobalInfo') -> None:
+def generate_makefile(gx: "config.GlobalInfo") -> None:
     """Generate a makefile"""
     if gx.nomakefile:
         return
@@ -60,7 +60,7 @@ def generate_makefile(gx: 'config.GlobalInfo') -> None:
 
     makefile = open(makefile_path, "w")
 
-    def write(line: str="") -> None:
+    def write(line: str = "") -> None:
         print(line, file=makefile)
 
     esc_space = "\ "
@@ -86,11 +86,11 @@ def generate_makefile(gx: 'config.GlobalInfo') -> None:
     cppfiles = [fn + ".cpp" for fn in filenames]
     hppfiles = [fn + ".hpp" for fn in filenames]
     # used to be 're', but currently unused, but kept around just in case
-#for always in ():
-#        repath = os.path.join(env_var("SHEDSKIN_LIBDIR"), always)
-#        if repath not in filenames:
-#            cppfiles.append(repath + ".cpp")
-#            hppfiles.append(repath + ".hpp")
+    # for always in ():
+    #        repath = os.path.join(env_var("SHEDSKIN_LIBDIR"), always)
+    #        if repath not in filenames:
+    #            cppfiles.append(repath + ".cpp")
+    #            hppfiles.append(repath + ".hpp")
 
     cppfiles.sort(reverse=True)
     hppfiles.sort(reverse=True)
@@ -111,11 +111,11 @@ def generate_makefile(gx: 'config.GlobalInfo') -> None:
     else:
         flags = gx.shedskin_flags / "FLAGS"
 
-    line = ''
+    line = ""
     for line in open(flags):
         line = line[:-1]
 
-        variable = line[: line.find("=")].strip().rstrip('?')
+        variable = line[: line.find("=")].strip().rstrip("?")
 
         if variable == "CXXFLAGS":
             line += " -I. -I%s" % env_var("SHEDSKIN_LIBDIR")

--- a/shedskin/utils.py
+++ b/shedskin/utils.py
@@ -1,7 +1,6 @@
 # SHED SKIN Python-to-C++ Compiler
 # Copyright 2005-2024 Mark Dufour and contributors; GNU GPL version 3 (See LICENSE)
-"""shedskin.utils: miscellaneous utilities
-"""
+"""shedskin.utils: miscellaneous utilities"""
 
 # terminal codes
 MOVE = "\x1b[1G"

--- a/shedskin/virtual.py
+++ b/shedskin/virtual.py
@@ -34,10 +34,10 @@ from . import python
 from . import typestr
 from . import cpp
 
-from typing import List, Any
+from typing import Any
 
 
-def virtuals(self: 'cpp.GenerateVisitor', cl: 'python.Class', declare: bool) -> None:
+def virtuals(self: "cpp.GenerateVisitor", cl: "python.Class", declare: bool) -> None:
     """Generate virtual methods for a class"""
     if not cl.virtuals:
         return
@@ -128,7 +128,7 @@ def virtuals(self: 'cpp.GenerateVisitor', cl: 'python.Class', declare: bool) -> 
 
 
 # --- determine virtual methods and variables
-def analyze_virtuals(gx: 'config.GlobalInfo') -> None:
+def analyze_virtuals(gx: "config.GlobalInfo") -> None:
     """Analyze virtual methods and variables"""
     for node in gx.merged_inh:
         # --- for every message
@@ -171,11 +171,11 @@ def analyze_virtuals(gx: 'config.GlobalInfo') -> None:
 
 
 def upgrade_cl(
-    gx: 'config.GlobalInfo',
-    abstract_cl: 'python.Class',
+    gx: "config.GlobalInfo",
+    abstract_cl: "python.Class",
     node: Any,
     ident: str,
-    classes: set['python.Class'],
+    classes: set["python.Class"],
 ) -> None:
     """Upgrade a class"""
     subclasses = [cl for cl in classes if python.subclass(cl, abstract_cl)]


### PR DESCRIPTION
Quite a few formatting improvements due to `ruff format` and also some fixes due to `ruff check`.

One change to note is that in many cases where code like`type(node.op) == ast.Add` was used, it was changed to `isinstance(node.op, ast.Node)` with no loss of semantics.

Checks were run on my system before PR