### PR TITLE
Added direct compilation feature to shedskin.translate

### DIFF
--- a/shedskin/__init__.py
+++ b/shedskin/__init__.py
@@ -256,6 +256,7 @@ class Shedskin:
         opt("-m", "--makefile",     help="Specify alternate Makefile name")
         opt("-o", "--outputdir",    help="Specify output directory for generated files")
 #        opt("-r", "--random",       help="Use fast random number generator (rand())", action="store_true")
+        opt("-r", "--run",          help="Build and run executable", action="store_true")
         opt("-s", "--silent",       help="Silent mode, only show warnings", action="store_true")
         opt("-t", "--traceback",    help="Print traceback for uncaught exceptions", action="store_true")
         opt("-x", "--executable",   help="Generate executable", action="store_true")
@@ -272,7 +273,7 @@ class Shedskin:
         opt("--nogc",               help="Disable garbage collection", action="store_true")
         opt("--nomakefile",         help="Disable makefile generation", action="store_true")
         opt("-w", "--nowrap",       help="Disable wrap-around checking", action="store_true")
-
+        opt("--nocleanup",          help="Disable cleanup of generated files", action="store_true")
         parser_build = subparsers.add_parser('build', help="translate and build python module (CMake)")
         arg = opt = parser_build.add_argument
 

--- a/shedskin/__init__.py
+++ b/shedskin/__init__.py
@@ -244,6 +244,7 @@ class Shedskin:
 
         arg("name", help="Python file or module to compile")
 
+        arg("-c", "--compile",      help="Directly compile translated code", action="store_true")
         opt("-d", "--debug",        help="Set debug level", type=int)
         opt("-e", "--extmod",       help="Generate extension module", action="store_true")
         opt("-F", "--flags",        help="Provide alternate Makefile flags")
@@ -251,12 +252,14 @@ class Shedskin:
         opt("-L", "--link-dirs",    help="Add a link library directory", action="append")
         opt("-l", "--link-libs",    help="Add a link library", action="append")
         opt("-X", "--extra-lib",    help="Add an extra builtins library directory")
+        opt("-S", "--static-libs",  help="Use static compilation if possible", action="store_true")
         opt("-m", "--makefile",     help="Specify alternate Makefile name")
         opt("-o", "--outputdir",    help="Specify output directory for generated files")
 #        opt("-r", "--random",       help="Use fast random number generator (rand())", action="store_true")
         opt("-s", "--silent",       help="Silent mode, only show warnings", action="store_true")
         opt("-t", "--traceback",    help="Print traceback for uncaught exceptions", action="store_true")
         opt("-x", "--executable",   help="Generate executable", action="store_true")
+        opt("-D", "--dry-run",      help="Only print compilation command", action="store_true")
 
         opt("--int32",              help="Use 32-bit integers", action="store_true")
         opt("--int64",              help="Use 64-bit integers", action="store_true")
@@ -268,7 +271,7 @@ class Shedskin:
         opt("-b", "--nobounds",     help="Disable bounds checking", action="store_true")
         opt("--nogc",               help="Disable garbage collection", action="store_true")
         opt("--nomakefile",         help="Disable makefile generation", action="store_true")
-        opt("-w", "--nowrap",             help="Disable wrap-around checking", action="store_true")
+        opt("-w", "--nowrap",       help="Disable wrap-around checking", action="store_true")
 
         parser_build = subparsers.add_parser('build', help="translate and build python module (CMake)")
         arg = opt = parser_build.add_argument

--- a/shedskin/lib/builtin/function.cpp
+++ b/shedskin/lib/builtin/function.cpp
@@ -185,15 +185,23 @@ str *__xrange::__repr__() {
 }
 
 __xrange *__xrange::__slice__(__ss_int x, __ss_int l, __ss_int u, __ss_int s_) {
-    if(x&1)
-        l = a+l*s;
-    else
+    if(x&1) {
+        if(l < 0)
+            l = b+l*s;
+        else
+            l = a+l*s;
+    } else {
         l = a;
+    }
 
-    if(x&2)
-        u = a+u*s;
-    else
+    if(x&2) {
+        if(u < 0)
+            u = b+u*s;
+        else
+            u = a+u*s;
+    } else {
         u = b;
+    }
 
     if(x&4)
         s_ = s*s_;

--- a/shedskin/makefile.py
+++ b/shedskin/makefile.py
@@ -283,6 +283,13 @@ class Builder:
             for path in Path(".").glob(pattern):
                 self._remove(path)
 
+    def run_executable(self) -> None:
+        """Run the executable"""
+        print()
+        print("-" * 80)
+        print(f"Running {self.target}")
+        self._execute(f"./{self.target}")
+
     @property
     def build_cmd(self) -> str:
         """Get the executable or extension build command"""
@@ -632,8 +639,13 @@ class ShedskinBuilder(Builder):
 
     def _add_cleanup_patterns(self) -> None:
         """Add cleanup patterns to the configuration"""
-        if PLATFORM == "Darwin" and self.gx.pyextension_product:
+        if PLATFORM == "Darwin" and self.gx.pyextension_product and not self.gx.options.nocleanup:
             self.add_cleanups("*.dSYM")
+        if not self.gx.options.nocleanup:
+            self.add_cleanups(
+                f"{self.target_name}.cpp",
+                f"{self.target_name}.hpp",
+            )
 
 
 class MakefileGenerator:
@@ -1189,9 +1201,14 @@ def generate_makefile(gx: "config.GlobalInfo") -> None:
     if gx.options.compile:
         builder = ShedskinBuilder(gx)
         builder.build(gx.options.dry_run)
+    elif gx.options.run:
+        builder = ShedskinBuilder(gx)
+        builder.build(gx.options.dry_run)
+        builder.run_executable()
     else:
         generator = ShedskinMakefileGenerator(gx)
         generator.generate()
+    
 
 
 if __name__ == "__main__":

--- a/shedskin/makefile.py
+++ b/shedskin/makefile.py
@@ -130,12 +130,12 @@ class PythonSystem:
 
     @property
     def name_version(self) -> str:
-        """return name-<fullversion>: e.g. Python-3.11.7"""
+        """return <name>-<fullversion>: e.g. Python-3.11.7"""
         return f"{self.name}-{self.version}"
 
     @property
     def name_ver(self) -> str:
-        """return name.lower-<ver>: e.g. python3.11"""
+        """return <name.lower><ver>: e.g. python3.11"""
         return f"{self.name.lower()}{self.ver}"
 
     @property
@@ -250,6 +250,7 @@ class Builder:
 
     def _execute(self, cmd: str) -> None:
         """Execute a command"""
+        print(cmd)
         os.system(cmd)
 
     def _remove(self, path: PathLike) -> None:
@@ -273,6 +274,7 @@ class Builder:
         if dry_run:
             print(self.build_cmd)
         else:
+            print()
             self._execute(self.build_cmd)
             if self.cleanups:
                 self.clean()


### PR DESCRIPTION
Instead of adding another subcommand, I have in this PR, added a `-c, --compile` flag to `shedkin translate` as below as well as `-S, --static-libs` and also `--dry-run` options (see below for the revised api):

If `shedskin translate -c demo.py` is used at the command line, makefile generation is skipped and an executable is built via direct compilation  (relevant code is  in `shedskin.makefile.ShedskinBuilder`).

If `shedskin translate -ec demo.py` is used, a pyextension is built (no cleanup of detritus is included at this stage, but can be added later).

If `-S` or `--static-libs` is used with either of the above, the executable or pyextension is compiled and statically linked to gc and pcre.

```sh
% shedskin translate --help
usage: shedskin translate [-h] [-c] [-d DEBUG] [-e] [-F FLAGS]
                          [-I INCLUDE_DIRS] [-L LINK_DIRS] [-l LINK_LIBS]
                          [-X EXTRA_LIB] [-S] [-m MAKEFILE] [-o OUTPUTDIR]
                          [-s] [-t] [-x] [-D] [--int32] [--int64] [--int128]
                          [--float32] [--float64] [--noassert] [-b] [--nogc]
                          [--nomakefile] [-w]
                          name

positional arguments:
  name                  Python file or module to compile

options:
  -h, --help            show this help message and exit
  -c, --compile         Directly compile translated code
  -d, --debug DEBUG     Set debug level
  -e, --extmod          Generate extension module
  -F, --flags FLAGS     Provide alternate Makefile flags
  -I, --include-dirs INCLUDE_DIRS
                        Add an include directory
  -L, --link-dirs LINK_DIRS
                        Add a link library directory
  -l, --link-libs LINK_LIBS
                        Add a link library
  -X, --extra-lib EXTRA_LIB
                        Add an extra builtins library directory
  -S, --static-libs     Use static compilation if possible
  -m, --makefile MAKEFILE
                        Specify alternate Makefile name
  -o, --outputdir OUTPUTDIR
                        Specify output directory for generated files
  -s, --silent          Silent mode, only show warnings
  -t, --traceback       Print traceback for uncaught exceptions
  -x, --executable      Generate executable
  -D, --dry-run         Only print compilation command
  --int32               Use 32-bit integers
  --int64               Use 64-bit integers
  --int128              Use 128-bit integers
  --float32             Use 32-bit floats
  --float64             Use 64-bit floats
  --noassert            Disable assert statements
  -b, --nobounds        Disable bounds checking
  --nogc                Disable garbage collection
  --nomakefile          Disable makefile generation
  -w, --nowrap          Disable wrap-around checking
```

Please test... and let me know if you want to rethink the api which is deliberately low impact.
