### PR TITLE
Update __init__.py: add a hack that enables color output for Microsoft Windows cmd

### DIFF
--- a/shedskin/__init__.py
+++ b/shedskin/__init__.py
@@ -251,6 +251,7 @@ class Shedskin:
     def commandline(cls, bypassargs:Optional[List[str]]=None) -> None:
         """command line api"""
         sys.setrecursionlimit(100000)
+        os.system("") # hack tht enables color output for Microsoft Windows cmd
 
         # --- command-line options
         parser = argparse.ArgumentParser(


### PR DESCRIPTION
This is a well-known workaround for enabling ansi codes on windows cmd, which I still use. https://github.com/python/cpython/issues/74261