### PR TITLE
Attempt to port from libpcre3 to libpcre2.

### DIFF
--- a/shedskin/lib/re.hpp
+++ b/shedskin/lib/re.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2005-2011 Mark Dufour and contributors; License Expat (See LICENSE) */
+/* Copyright 2005-2025 Mark Dufour and contributors; License Expat (See LICENSE) */
 
 #ifndef __RE_HPP
 #define __RE_HPP
@@ -8,10 +8,12 @@
 
 #include "builtin.hpp"
 
+#define PCRE2_CODE_UNIT_WIDTH 8
+
 #ifndef __sun
-#include <pcre.h>
+#include <pcre2.h>
 #else
-#include <pcre/pcre.h>
+#include <pcre2/pcre2.h>
 #endif
 
 
@@ -53,7 +55,7 @@ public:
     re_object *re;
 
     //internal: captured subpatterns
-    int *captured;
+    pcre2_match_data *match_data;
 
     //self-explanatory
     __ss_int pos, endpos;
@@ -129,13 +131,12 @@ public:
     __ss_int flags;
 
     //internal functions
-    __GC_STRING __group(__GC_STRING *subj, int *captured, __ss_int m);
-    __GC_STRING __group(__GC_STRING *subj, int *captured, str *m);
-    __GC_STRING __expand(__GC_STRING *subj, int *captured, __GC_STRING tpl);
+    __GC_STRING __group(__GC_STRING *subj, PCRE2_SIZE *captured, __ss_int m);
+    __GC_STRING __group(__GC_STRING *subj, PCRE2_SIZE *captured, str *m);
+    __GC_STRING __expand(__GC_STRING *subj, PCRE2_SIZE *captured, __GC_STRING tpl);
 
-    //the compiled pattern + extra info for optimization
-    pcre *compiled_pattern;
-    pcre_extra *study_info;
+    //the compiled pattern
+    pcre2_code *compiled_pattern;
 
     match_object *__exec(str *subj, __ss_int pos = 0, __ss_int endpos = -1, __ss_int flags_ = 0);
     str *__subn(str *repl, str *subj, __ss_int maxn = -1, int *howmany = 0);
@@ -182,8 +183,8 @@ match_object *__exec_once(str *subj, __ss_int flags);
 //internal functions
 void __init(void);
 
-void *re_malloc(size_t n);
-void re_free(void *o);
+void *re_malloc(size_t n, void *);
+void re_free(void *o, void *);
 
 }
 #endif

--- a/shedskin/resources/cmake/fn_add_shedskin_product.cmake
+++ b/shedskin/resources/cmake/fn_add_shedskin_product.cmake
@@ -111,11 +111,7 @@ function(add_shedskin_product)
     if(SHEDSKIN_CMDLINE_OPTIONS)
         join(${SHEDSKIN_CMDLINE_OPTIONS} " " opts)
     else()
-        if(COLLECT_STATS)
-            set(opts "--collect-stats")
-        else()
-            set(opts)
-        endif()
+        set(opts)
     endif()
 
     if(SIMPLE_PROJECT)
@@ -215,11 +211,11 @@ function(add_shedskin_product)
     if (UNIX)
         set(LIBGC libgc.a)
         set(LIBGCCPP libgccpp.a)
-        set(LIBGPCRE libpcre.a)
+        set(LIBGPCRE libpcre2-8.a)
     else() # i.e windows
         set(LIBGCa gc.lib)
         set(LIBGCCPP gccpp.lib)
-        set(LIBPCRE pcre.lib)
+        set(LIBPCRE pcre2-8.lib)
     endif ()
 
     if(ENABLE_EXTERNAL_PROJECT)
@@ -276,7 +272,7 @@ function(add_shedskin_product)
         set(LIB_DEPS
             "-lgc"
             "-lgccpp"
-            "$<$<BOOL:${IMPORTS_RE_MODULE}>:-lpcre>"
+            "$<$<BOOL:${IMPORTS_RE_MODULE}>:-lpcre2-8>"
             # "$<$<BOOL:${IMPORTS_OS_MODULE}>:-lutil>"
             ${SHEDSKIN_LINK_LIBS}
         )

--- a/shedskin/resources/cmake/install_deps.cmake
+++ b/shedskin/resources/cmake/install_deps.cmake
@@ -24,7 +24,7 @@ function(common)
         set(LIB_DEPS
             ${install_dir}/lib/libgc.a
             ${install_dir}/lib/libgccpp.a
-            $<$<BOOL:${IMPORTS_RE_MODULE}>:${install_dir}/lib/libpcre.a>
+            $<$<BOOL:${IMPORTS_RE_MODULE}>:${install_dir}/lib/libpcre2-8.a>
         )
         set(LIB_DIRS ${install_dir}/lib)
         set(LIB_INCLUDES ${install_dir}/include)
@@ -32,7 +32,7 @@ function(common)
         set(LIB_DEPS
             ${SPM_LIB_DIRS}/libgc.a
             ${SPM_LIB_DIRS}/libgccpp.a
-            $<$<BOOL:${IMPORTS_RE_MODULE}>:${SPM_LIB_DIRS}/libpcre.a>            
+            $<$<BOOL:${IMPORTS_RE_MODULE}>:${SPM_LIB_DIRS}/libpcre2-8.a>            
         )
         set(LIB_DIRS ${SPM_LIB_DIRS})
         set(LIB_INCLUDES ${SPM_INCLUDE_DIRS})
@@ -72,7 +72,7 @@ function(common)
         set(LIB_DEPS 
             "-lgc"
             "-lgccpp"
-            "$<$<BOOL:${IMPORTS_RE_MODULE}>:-lpcre>"
+            "$<$<BOOL:${IMPORTS_RE_MODULE}>:-lpcre2-8>"
             # "$<$<BOOL:${IMPORTS_OS_MODULE}>:-lutil>"
             ${SHEDSKIN_LINK_LIBS}
         )

--- a/shedskin/resources/flags/FLAGS.mingw
+++ b/shedskin/resources/flags/FLAGS.mingw
@@ -1,4 +1,4 @@
 CXX?=g++
 CXXFLAGS?=-O2 -DWIN32 -std=c++17 -march=native -Wno-deprecated -Wl,--enable-auto-import $(CPPFLAGS)
-LDLIBS?=-lgc -lpcre -lgccpp
+LDLIBS?=-lgc -lpcre2-8 -lgccpp
 

--- a/shedskin/resources/flags/FLAGS.osx
+++ b/shedskin/resources/flags/FLAGS.osx
@@ -1,3 +1,3 @@
 CXX?=g++
 CXXFLAGS?=-O2 -std=c++17 -Wno-deprecated $(CPPFLAGS)
-LDLIBS?=-lgc -lgctba -lpcre
+LDLIBS?=-lgc -lgctba -lpcre2-8


### PR DESCRIPTION
Since libpcre3 is being pushed off the table by most Linux distributions, with libpcre2 being the apparent (but counterintuitive) successor, this patch attempts to adopt the slightly different API of libpcre2 in the re module.