### PR TITLE
fix for gcc on new raspberry-pi

### DIFF
--- a/shedskin/lib/builtin/math.hpp
+++ b/shedskin/lib/builtin/math.hpp
@@ -215,7 +215,7 @@ inline __ss_int __ss_bit_length(__ss_int i) {
 }
 
 namespace __bytes___ {
-    static char table_a2b_hex[] = { // TODO merge with binascii.. or use C++ function?
+    static signed char table_a2b_hex[] = { // TODO merge with binascii.. or use C++ function?
         -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
         -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
         -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,


### PR DESCRIPTION
not sure why it gives an error here, not just a warning