### PR TITLE
make __unpack_check() into a macro

### DIFF
--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -3317,7 +3317,7 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
                         rvalue_node, ("list", "str_", "bytes_", "tuple", "tuple2")
                     ):
                         self.output(
-                            "__unpack_check(%s, %d);" % (temp, len(lvalue.elts))
+                            "__SS_UNPACK_CHECK(%s, %d);" % (temp, len(lvalue.elts))
                         )
                     else:
                         rtypes = self.mergeinh[rvalue_node]
@@ -3330,7 +3330,7 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
                         )
                         temp = temp + "_list"
                         self.output(
-                            "__unpack_check(%s, %d);" % (temp, len(lvalue.elts))
+                            "__SS_UNPACK_CHECK(%s, %d);" % (temp, len(lvalue.elts))
                         )
 
                 self.start()

--- a/shedskin/lib/builtin.hpp
+++ b/shedskin/lib/builtin.hpp
@@ -438,12 +438,15 @@ template<class T> T __seqiter<T>::__next__() {
 
 /* tuple unpacking */
 
-template<class T> void __unpack_check(T t, int expected) {
-    if(len(t) > (__ss_int)expected)
-	 throw new ValueError(new str("too many values to unpack"));
-    else if(len(t) < (__ss_int)expected)
-	 throw new ValueError(new str("not enough values to unpack"));
-}
+#ifdef __SS_NOBOUNDS
+    #define __SS_UNPACK_CHECK(t, expected)
+#else
+#define __SS_UNPACK_CHECK(t, expected) \
+    if(len(t) > (__ss_int)expected) \
+        throw new ValueError(new str("too many values to unpack")); \
+    else if(len(t) < (__ss_int)expected) \
+        throw new ValueError(new str("not enough values to unpack"));
+#endif
 
 /* init/exit */
 


### PR DESCRIPTION
this probably helps avoiding exception handling overhead, which in tight loops can make a very big difference.

also disable it when using --nobounds.

these make examples/voronoi increasingly faster.

it does make one wonder about the regular wrap/bounds check.. could this be faster as well as a (partial) macro?