### PR TITLE
pre-allocate small-int tuples

### DIFF
--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -1158,7 +1158,10 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
         if ts.startswith("pyseq") or ts.startswith("pyiter"):  # XXX
             argtypes = self.gx.merged_inh[node]
         ts = typestr.typestr(self.gx, argtypes, mv=self.mv)
-        self.append("(new " + ts[:-2] + "(")
+        if ts == 'tuple<__ss_int> *' and len(node.elts) == 2:
+            self.append("(__ss_tuple_int(")
+        else:
+            self.append("(new " + ts[:-2] + "(")
         return argtypes
 
     def visit_Dict(

--- a/shedskin/lib/builtin.cpp
+++ b/shedskin/lib/builtin.cpp
@@ -34,6 +34,8 @@ str *__ss_empty_str;
 
 file *__ss_stdin, *__ss_stdout, *__ss_stderr;
 
+tuple<__ss_int> *__ss_tuple_cache[1024];
+
 #ifdef __SS_BIND
 dict<void *, void *> *__ss_proxy;
 #endif
@@ -108,6 +110,10 @@ void __init() {
         else
             __case_swap_cache->unit += (char)::tolower(c);
     }
+
+    for(__ss_int i=0; i<32; i++)
+        for(__ss_int j=0; j<32; j++)
+            __ss_tuple_cache[i*32+j] = new tuple<__ss_int>(2, i-16, j-16);
 
     __ss_stdin = new file(stdin);
     __ss_stdin->name = new str("<stdin>");
@@ -384,5 +390,15 @@ void slicenr(__ss_int x, __ss_int &l, __ss_int &u, __ss_int &s, __ss_int len) {
             u = len;
     }
 }
+
+/* tuple caching */
+
+tuple<__ss_int >*__ss_tuple_int(__ss_int, __ss_int a, __ss_int b) {
+    if(-16 <= a && a < 16 && -16 <= b && b < 16)
+        return __ss_tuple_cache[(a+16)*32+(b+16)];
+    else
+        return new tuple<__ss_int>(2, a, b);
+}
+
 
 } // namespace __shedskin__

--- a/shedskin/lib/builtin.hpp
+++ b/shedskin/lib/builtin.hpp
@@ -448,6 +448,8 @@ template<class T> T __seqiter<T>::__next__() {
         throw new ValueError(new str("not enough values to unpack"));
 #endif
 
+tuple<__ss_int >*__ss_tuple_int(__ss_int n, __ss_int a, __ss_int b);
+
 /* init/exit */
 
 void __init();


### PR DESCRIPTION
for now, just for 2-len tuples and ints -16 <= .. < 16

this helps othello by about 10% and rubik by about 25%, and probably helps other examples too (I only measured these two).

we can further tweak this as needed.