### PR TITLE
optimize str.{startswith, endswith} common case

### DIFF
--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -596,6 +596,7 @@ __ss_int str::count(str *s, __ss_int start, __ss_int end) {
     return count;
 }
 
+__ss_bool str::startswith(str *s) { return __mbool(this->unit.starts_with(s->unit)); }
 __ss_bool str::startswith(str *s, __ss_int start) { return startswith(s, start, __len__()); }
 __ss_bool str::startswith(str *s, __ss_int start, __ss_int end) {
     __ss_int one = 1;
@@ -609,6 +610,7 @@ __ss_bool str::startswith(str *s, __ss_int start, __ss_int end) {
     return __mbool(j == s->unit.size());
 }
 
+__ss_bool str::endswith(str *s) { return __mbool(this->unit.ends_with(s->unit)); }
 __ss_bool str::endswith(str *s, __ss_int start) { return endswith(s, start, __len__()); }
 __ss_bool str::endswith(str *s, __ss_int start, __ss_int end) {
     __ss_int one = 1;

--- a/shedskin/lib/builtin/str.hpp
+++ b/shedskin/lib/builtin/str.hpp
@@ -93,9 +93,11 @@ public:
     __ss_bool isdecimal();
     __ss_bool isidentifier();
 
-    __ss_bool startswith(str *s, __ss_int start=0);
+    __ss_bool startswith(str *s);
+    __ss_bool startswith(str *s, __ss_int start);
     __ss_bool startswith(str *s, __ss_int start, __ss_int end);
-    __ss_bool endswith(str *s, __ss_int start=0);
+    __ss_bool endswith(str *s);
+    __ss_bool endswith(str *s, __ss_int start);
     __ss_bool endswith(str *s, __ss_int start, __ss_int end);
 
     str *zfill(__ss_int width);


### PR DESCRIPTION
use c++20 starts_with, ends_with