### PR TITLE
make --nogc avoid all things libgc

### DIFF
--- a/shedskin/lib/builtin.cpp
+++ b/shedskin/lib/builtin.cpp
@@ -40,13 +40,14 @@ tuple<__ss_int> *__ss_tuple_cache[1600];
 dict<void *, void *> *__ss_proxy;
 #endif
 
+#ifndef __SS_NOGC
 void gc_warning_handler(char *, GC_word) {}
+#endif
 
 void __init() {
+#ifndef __SS_NOGC
     GC_INIT();
     GC_set_warn_proc(gc_warning_handler);
-#ifdef __SS_NOGC
-    GC_disable();
 #endif
 
 #ifdef __SS_BIND

--- a/shedskin/lib/collections.hpp
+++ b/shedskin/lib/collections.hpp
@@ -16,8 +16,13 @@ template <class T> class __dequeiter;
 extern class_ *cl_deque;
 template <class A> class deque : public pyiter<A> {
 public:
+#ifdef __SS_NOGC
+    std::deque<A> units;
+    typename std::deque<A>::iterator iter;
+#else
     std::deque<A, gc_allocator<A> > units;
     typename std::deque<A, gc_allocator<A> >::iterator iter;
+#endif
 
     /* XXX modulo rotate, maxlen */
 


### PR DESCRIPTION
not not just disabling collection, but also custom allocator.

this makes it easier to use memory profilers, at least for me.

to use valgrind --tool=massif, for example:

shedskin --nogc test
in makefile: use -g -O0 and remove -march=native
valgrind --tool=massif ./test
massif-visualizer massif.out.xxx