### PR TITLE
optimize [expr] * expr, expr * [expr]

### DIFF
--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -2497,6 +2497,26 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
             self.append(")")
             return
 
+        # -- optimize: [elem] * n
+        if (
+            middle == "__mul__"
+            and isinstance(left, ast.List)
+            and len(left.elts) == 1
+        ):
+            type_child = self.subtypes(ltypes, "unit")
+            ts_child = typestr.typestr(self.gx, type_child, mv=self.mv)
+            self.visitm("__ss_listmul<%s>(" % ts_child, left.elts[0], ", ", right, ")", func)
+            return
+        if (
+            middle == "__mul__"
+            and isinstance(right, ast.List)
+            and len(right.elts) == 1
+        ):
+            type_child = self.subtypes(rtypes, "unit")
+            ts_child = typestr.typestr(self.gx, type_child, mv=self.mv)
+            self.visitm("__ss_listmul2<%s>(" % ts_child, left, ", ", right.elts[0], ")", func)
+            return
+
         # --- 'a.__mul__(b)': use template to call to b.__mul__(a), while maintaining evaluation order
         if inline in ["+", "*", "-", "/"] and ul and not ur:
             self.append(

--- a/shedskin/lib/builtin.hpp
+++ b/shedskin/lib/builtin.hpp
@@ -470,6 +470,20 @@ template<class T> list<T> *__ss_list() {
     return l;
 }
 
+template<class T> inline list<T> *__ss_listmul(T t, __ss_int n) {
+    list<T> *l =  new list<T>();
+    if(n > 0)
+        l->units.assign(n, t);
+    return l;
+}
+
+template<class T> inline list<T> *__ss_listmul2(__ss_int n, T t) {
+    list<T> *l =  new list<T>();
+    if(n > 0)
+        l->units.assign(n, t);
+    return l;
+}
+
 inline list<__ss_int> *__ss_list_range(__ss_int a, __ss_int b, __ss_int c) {
     list<__ss_int> *l = new list<__ss_int>();
     __ss_int len = range_len(a, b, c);


### PR DESCRIPTION
can be replaced with a list comprehension, but this is probably more efficient (and idiomatic).