### PR TITLE
make test_dep_* workflows manual as ci already runs tests

### DIFF
--- a/.github/workflows/test_dep_managers.yml
+++ b/.github/workflows/test_dep_managers.yml
@@ -1,11 +1,11 @@
 name: test-dep-managers
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
-  workflow_dispatch:
+on: [workflow_dispatch]
+  # push:
+  #   branches: [ "master" ]
+  # pull_request:
+  #   branches: [ "master" ]
+  # workflow_dispatch:
 
 concurrency:
   group: dep-managers-${{ github.ref }}

--- a/.github/workflows/test_dep_managers_extended.yml
+++ b/.github/workflows/test_dep_managers_extended.yml
@@ -1,7 +1,6 @@
 name: test-dep-managers-extended
 
-on:
-  workflow_dispatch:
+on: [workflow_dispatch]
 
 concurrency:
   group: dep-managers-extended-${{ github.ref }}


### PR DESCRIPTION
This is to eliminate waste and redundancy as the test_dep_* workflows were originally created to ensure the change in the default dep manager worked and they have done this well. 

Now that this is stable, we don't need three ci-like workflows and the test_dep_* workflows are now available for manual running instead of being run with every commit.

