### PR TITLE
fix virtuals issue with c64 example

### DIFF
--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -1798,7 +1798,7 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
         elif func.returnexpr:
             assert func.retnode
             if func.ftypes:
-                header += func.ftypes[0]
+                header += typestr.typestr(self.gx, func.ftypes[0], mv=self.mv)
             else:
                 header += typestr.nodetypestr(
                     self.gx, func.retnode.thing, func, mv=self.mv
@@ -1814,7 +1814,7 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
         # if arguments type too precise (e.g. virtually called) cast them back
         oldftypes = ftypes
         if func.ftypes:
-            ftypes = func.ftypes[1:]
+            ftypes = [typestr.typestr(self.gx, ft, mv=self.mv) for ft in func.ftypes[1:]]
 
         # --- method header
         if method and not declare:

--- a/shedskin/python.py
+++ b/shedskin/python.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
 Parent: TypeAlias = Union["Class", "Function"]
 AllParent: TypeAlias = Union["Class", "Function", "StaticClass"]
 CartesianProduct: TypeAlias = Tuple[Tuple["Class", int], ...]
+Types: TypeAlias = set[Tuple["Class", int]]
 
 
 class PyObject:
@@ -307,7 +308,7 @@ class Function:
         self.yieldNodes: List[ast.Yield] = []
         self.yieldnode: "infer.CNode"
         # function is called via a virtual call: arguments may have to be cast
-        self.ftypes: List[str] = []
+        self.ftypes: List[Types] = []
 
         if node:
             self.gx.allfuncs.add(self)

--- a/shedskin/virtual.py
+++ b/shedskin/virtual.py
@@ -91,7 +91,7 @@ def virtuals(self: "cpp.GenerateVisitor", cl: "python.Class", declare: bool) -> 
         # --- prepare for having to cast back arguments (virtual function call means multiple targets)
         for subcl in subclasses:
             if ident in subcl.funcs:
-                subcl.funcs[ident].ftypes = ftypes
+                subcl.funcs[ident].ftypes = merged
 
         # --- virtual function declaration
         if declare:


### PR DESCRIPTION
change ftypes from typestr to types, so we can 'render' them in another module (affecting class module paths in this case).