### PR TITLE
add translate --retry

### DIFF
--- a/shedskin/__init__.py
+++ b/shedskin/__init__.py
@@ -104,6 +104,9 @@ class Shedskin:
                 if args.debug >= 3:
                     self.infer_log.setLevel(logging.DEBUG)
 
+            if args.retry:
+                gx.retry_maxiters = True
+
             if args.int32:
                 gx.int32 = True
 
@@ -216,9 +219,16 @@ class Shedskin:
 
     def translate(self) -> None:
         """Translate the main module"""
-        self.pre_analyze()
-        t0 = time.time()
-        infer.analyze(self.gx, self.module_name)
+        while True:
+            try:
+                self.pre_analyze()
+                t0 = time.time()
+                infer.analyze(self.gx, self.module_name)
+                break
+            except infer.MaxIterationsException:
+                self.log.info("[restarting analysis]")
+                self.gx = self.configure(self.gx.options)
+                self.module_name = self.get_name(self.gx.options.name)
         cpp.generate_code(self.gx)
         error.print_errors()
         prebuild_secs = time.time() - t0
@@ -319,6 +329,7 @@ class Shedskin:
         grp("-l", "--link-libs", help="Add a link library", action="append")
         grp("-X", "--extra-lib", help="Add an extra builtins library directory")
         grp("-o", "--outputdir", help="Specify output directory for generated files")
+        grp("--retry", help="Retry analysis when hitting max iterations", action="store_true")
         grp(
             "-s",
             "--silent",

--- a/shedskin/config.py
+++ b/shedskin/config.py
@@ -589,6 +589,14 @@ class GlobalInfo:
     def maxhits(self, value: int) -> None:
         self._type_inference.maxhits = value
 
+    @property
+    def retry_maxiters(self) -> int:
+        return self._type_inference.retry_maxiters
+
+    @retry_maxiters.setter
+    def retry_maxiters(self, value: bool) -> None:
+        self._type_inference.retry_maxiters = value
+
     def get_stats(self) -> dict[str, Any]:
         assert self.module_path is not None
         pyfile = Path(self.module_path)

--- a/shedskin/infer.py
+++ b/shedskin/infer.py
@@ -117,6 +117,10 @@ logger = logging.getLogger("infer")
 TRACE = False  # TODO add logging level?
 
 
+class MaxIterationsException(Exception):
+    pass
+
+
 def _const_str(node: ast.AST) -> str:
     """Return string value from a constant node."""
     assert isinstance(node, ast.Constant)
@@ -1851,6 +1855,8 @@ def iterative_dataflow_analysis(gx: "config.GlobalInfo") -> None:
                 update_progressbar(gx, perc)
             if maxiter:
                 logger.warning("reached maximum number of iterations")
+                if gx.retry_maxiters:
+                    raise MaxIterationsException
                 gx.maxhits += 1
                 if gx.maxhits == 3:
                     return
@@ -2004,7 +2010,7 @@ def ifa_seed_template(
                     gx.types[alloc_node].add(gx.alloc_info[alloc_id])
                     add_to_worklist(worklist, alloc_node)
 
-        if added_new and not func.mv.module.builtin:
+        if added_new and not func.mv.module.builtin:  # TODO improve logging
             logger.debug("%d seed(s): %s", added_new, func)
 
 

--- a/shedskin/state/type_inference.py
+++ b/shedskin/state/type_inference.py
@@ -61,3 +61,4 @@ class TypeInferenceState:
     cpa_limited: bool = False
     merged_inh: Dict[Any, Set[Tuple[Any, int]]] = field(default_factory=dict)
     maxhits: int = 0
+    retry_maxiters: bool = False


### PR DESCRIPTION
for a large test program, shedskin sometimes does not terminate. usually this coincides with a 'maximum iteration hit' warning.

add a --retry option, to restart the whole analysis on the first such hit.

because of the randomization in infer.py (class split order), this eventually/hopefully leads to a terminating analysis.

at least for the large test program, it now seems to always terminate correctly (tested 32 times).

todo:
  -also for build option
  -fix prebuild time