### PR TITLE
add min/max(default) argument stub

### DIFF
--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -3100,6 +3100,7 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
             parent_constr,
             anon_func,
         ) = infer.analyze_callfunc(self.gx, node, merge=self.gx.merged_inh)
+
         target: "python.Function"
         target = funcs[0]  # XXX
 
@@ -3167,7 +3168,7 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
             rest = func.largs
 
         assert target.node
-        if target.node.args.vararg:
+        if target.node.args.vararg or target.ident in ('__min1', '__max1'):
             assert isinstance(rest, int)
             self.append("%d" % rest)
             if rest or pairs:

--- a/shedskin/infer.py
+++ b/shedskin/infer.py
@@ -696,6 +696,8 @@ def analyze_callfunc(
         else:
             if namespace != mv.module:
                 return objexpr, ident, None, False, None, False, False
+        if direct_call and direct_call.ident in ('min', 'max'):  # TODO remove ident check
+            direct_call = redirect_func(direct_call, node)
 
     return (
         objexpr,
@@ -1107,20 +1109,11 @@ def possible_argtypes(
     return argtypes
 
 
-def redirect(
-    gx: "config.GlobalInfo",
-    c: CartesianProduct,
-    dcpa: int,
+def redirect_func(
     func: "python.Function",
     callfunc: ast.Call,
-    ident: Optional[str],
-    callnode: CNode,
-    direct_call: Optional["python.Function"],
-    constructor: Optional["python.Class"],
-) -> tuple[CartesianProduct, int, "python.Function"]:
-    """Redirect a call node"""
-
-    # redirect based on number of arguments (__%s%d syntax in builtins)
+) -> "python.Function":
+    """ redirect based on number of arguments (__%s%d syntax in builtins) """
     if func.mv.module.builtin:
         if isinstance(func.parent, python.Class):
             funcs = func.parent.funcs
@@ -1133,6 +1126,22 @@ def redirect(
             ),
         )
         func = funcs.get(redir, func)
+    return func
+
+
+def redirect(
+    gx: "config.GlobalInfo",
+    c: CartesianProduct,
+    dcpa: int,
+    func: "python.Function",
+    callfunc: ast.Call,
+    ident: Optional[str],
+    callnode: CNode,
+    direct_call: Optional["python.Function"],
+    constructor: Optional["python.Class"],
+) -> tuple[CartesianProduct, int, "python.Function"]:
+    """Redirect a call node"""
+    func = redirect_func(func, callfunc)
 
     # staticmethod
     if isinstance(func.parent, python.Class) and (

--- a/shedskin/lib/builtin.py
+++ b/shedskin/lib/builtin.py
@@ -1132,7 +1132,7 @@ def max(__kw_key=0, *arg): # XXX 0
     __cmp(arg, arg)
     __kw_key(arg)
     return arg
-def __max1(arg, __kw_key=0):
+def __max1(arg, __kw_key=0, __kw_default=0):
     elem = iter(arg).__next__()
     __cmp(elem, elem)
     __kw_key(elem)
@@ -1142,7 +1142,7 @@ def min(__kw_key=0, *arg): # XXX 0
     __cmp(arg, arg)
     __kw_key(arg)
     return arg
-def __min1(arg, __kw_key=0):
+def __min1(arg, __kw_key=0, __kw_default=0):
     elem = iter(arg).__next__()
     __cmp(elem, elem)
     __kw_key(elem)

--- a/shedskin/lib/builtin/function.hpp
+++ b/shedskin/lib/builtin/function.hpp
@@ -164,6 +164,7 @@ template<class A, class B> typename A::for_in_unit ___max(int, B (*key)(typename
     return max;
 }
 
+template<class A> typename A::for_in_unit ___max(int nn, A *iter) { return ___max(nn, (int (*)(typename A::for_in_unit))0, iter); }
 template<class A> typename A::for_in_unit ___max(int nn, int, A *iter) { return ___max(nn, (int (*)(typename A::for_in_unit))0, iter); }
 
 template<class T, class B> inline T ___max(int, B (*key)(T), T a, T b) { return (__cmp(key(a), key(b))==1)?a:b; }
@@ -200,7 +201,7 @@ template<class T, class ... Args> T ___max(int, int key, T a, T b, T c, Args ...
 template<class A, class B> typename A::for_in_unit ___min(int, B (*key)(typename A::for_in_unit), A *iter) {
     typename A::for_in_unit min;
     B minkey, minkey2;
-    min = __zero<typename A::for_in_unit>(); 
+    min = __zero<typename A::for_in_unit>();
     minkey = __zero<B>(); 
     minkey2 = __zero<B>();
     int first = 1;
@@ -224,6 +225,7 @@ template<class A, class B> typename A::for_in_unit ___min(int, B (*key)(typename
         throw new ValueError(new str("min() arg is an empty sequence"));
     return min;
 }
+template<class A> typename A::for_in_unit ___min(int nn, A *iter) { return ___min(nn, (int (*)(typename A::for_in_unit))0, iter); }
 template<class A> typename A::for_in_unit ___min(int nn, int, A *iter) { return ___min(nn, (int (*)(typename A::for_in_unit))0, iter); }
 
 template<class T, class B> inline T ___min(int, B (*key)(T), T a, T b) { return (__cmp(key(a), key(b))==-1)?a:b; }

--- a/tests/test_builtins/test_builtins.py
+++ b/tests/test_builtins/test_builtins.py
@@ -182,6 +182,8 @@ def test_max():
     assert max(xs) == 3
     assert max(xs, key=neg) == 1
 
+    assert max(xs, key=lambda y: -y) == 1
+
 
 def test_min():
     assert min([1]) == 1
@@ -204,6 +206,8 @@ def test_min():
     assert min(1, 2, key=neg) == 2
     assert min(xs) == 1
     assert min(xs, key=neg) == 3
+
+    assert min(xs, key=lambda u: -u) == 3
 
 
 def test_oct():


### PR DESCRIPTION
this silly stub actually uncovered some issues in redirection (to __min1/__max1).

next up is to actually support the argument!

what we probably want to do also is look into a better way to handle keyword-arguments on the C++ side (something templatey, rather than an int encoding which args are actually given, as for range()). let's see what we can come up with for min/max.