### PR TITLE
deque skip defaults

### DIFF
--- a/shedskin/infer.py
+++ b/shedskin/infer.py
@@ -485,6 +485,7 @@ def connect_actual_formal(
     if parent_constr:
         actuals = actuals[1:]
 
+    # TODO replace all this with __ss_void approach?
     skip_defaults = (
         False  # XXX investigate and further narrow down cases where we want to skip
     )
@@ -524,7 +525,18 @@ def connect_actual_formal(
             )
         )
     ):
-        if not (func.mv.module.ident == "math" and func.ident == "isclose"):
+        if (
+            not (
+                func.mv.module.ident == "math"
+                and func.ident == "isclose"
+            )
+            and not (
+                func.mv.module.ident == "collections"
+                and func.ident == "__init__"
+                and isinstance(func.parent, python.Class)
+                and func.parent.ident == 'deque'
+            )
+        ):
             skip_defaults = True
 
     actuals, formals, _, extra, _error = analyze_args(

--- a/shedskin/lib/collections.py
+++ b/shedskin/lib/collections.py
@@ -1,7 +1,7 @@
 # Copyright 2005-2026 Mark Dufour and contributors; License Expat (See LICENSE)
 
 class deque(pyiter):
-    def __init__(self, iterable=None, maxlen=None):
+    def __init__(self, iterable=None, maxlen=-1):
         self.unit = iter(iterable).__next__()
         self.maxlen = 1
 

--- a/tests/test_mod_collections/test_mod_collections.py
+++ b/tests/test_mod_collections/test_mod_collections.py
@@ -218,6 +218,10 @@ def test_deque_maxlen():
     e = d.copy()
     assert e.maxlen == 4
 
+    f = deque(maxlen=5)
+    f.extend(range(10))
+    assert list(f) == [5,6,7,8,9]
+
 
 def test_deque_maxlen_on_init():
     # regression test: maxlen used to be applied *after* the initial


### PR DESCRIPTION
- **fix int32/64 options**
- **cmake --boost**
- **fix int64 behaviour change, leading to LL constants**
- **heapq template fix**
- **fix deque(maxlen=) (only arg)**
