### PR TITLE
move sitestats.hpp includes to builtin.hpp

### DIFF
--- a/shedskin/lib/builtin.hpp
+++ b/shedskin/lib/builtin.hpp
@@ -99,6 +99,8 @@ inline void operator delete[](void *, std::align_val_t,
 #include <stdint.h>
 #include <limits>
 #include <numeric>
+#include <cstddef>
+
 
 #ifndef WIN32
 #include <cxxabi.h>

--- a/shedskin/lib/builtin/sitestats.hpp
+++ b/shedskin/lib/builtin/sitestats.hpp
@@ -3,9 +3,6 @@
 #ifndef SS_SITESTATS_HPP
 #define SS_SITESTATS_HPP
 
-#include <algorithm>
-#include <cstddef>
-
 /* Per-call-site backing-buffer size class, adapted online from
  * list.append() grow events.
  *


### PR DESCRIPTION
or it will confuse certain compilers

(introducing a __shedskin__::std namespace..)
