### PR TITLE
itertools.groupby: fix equality

### DIFF
--- a/shedskin/lib/itertools.hpp
+++ b/shedskin/lib/itertools.hpp
@@ -441,7 +441,7 @@ template<class T, class K> T groupiter<T, K>::__next__() {
     this->iter->current_value = this->iter->iter->__next__();;
     const K& new_key = this->iter->key(this->iter->current_value);
 
-    if (new_key != this->iter->current_key) {
+    if (__ne(new_key, this->iter->current_key)) {
         this->iter->current_key = new_key;
         this->iter->skip = false;
         throw new StopIteration();

--- a/shedskin/lib/itertools.py
+++ b/shedskin/lib/itertools.py
@@ -36,8 +36,9 @@ def __pred_elem(predicate, iterable):
 def dropwhile(predicate, iterable):
     yield __pred_elem(predicate, iterable)
 
-def groupby(iterable, key = lambda x: x):
-    yield key(iter(iterable).__next__()), iter(iterable)
+def groupby(iterable, key):  # TODO different types when key is given vs not.. specialize!
+    it = iter(iterable)
+    yield key(it.__next__()), it
 
 def filterfalse(predicate, iterable):
     yield __pred_elem(predicate, iterable)

--- a/tests/test_mod_itertools/test_mod_itertools.py
+++ b/tests/test_mod_itertools/test_mod_itertools.py
@@ -80,10 +80,13 @@ def key(x):
 def test_groupby():
     res = []
     for k, g in itertools.groupby([1, 4, 6, 4, 1], key):
-        for f in g:
-            res.append(f)
-        res.append(k)
-    assert res == [1, 4, 0, 6, 1, 4, 1, 0]
+        res.append((k, list(g)))
+    assert res == [(0, [1, 4]), (1, [6]), (0, [4, 1])]
+
+    res2 = []
+    for x, y in itertools.groupby([1,2,2,3,1,2], key=lambda x: str(-x)):
+        res2.append((x, list(y)))
+    assert res2 == [('-1', [1]), ('-2', [2, 2]), ('-3', [3]), ('-1', [1]), ('-2', [2])]
 
 
 def test_islice():


### PR DESCRIPTION
use _eq so it works also for pointer types
