### PR TITLE
Fix six runtime correctness bugs in 64-bit integer and float handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,36 +2,42 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Added
 
-- Added `--retry` option, that restarts the analysis when 'max iterations' occurs.
-  This can help a lot with larger programs (no need to manually retry).
+- Added `--retry` option, that restarts the analysis when 'max iterations' occurs. This can help a lot with larger programs (no need to manually retry).
 
-- Added `--boost` option, to use boost containers.
-  This can help when using dictionaries/sets or many very short lists.
-  The 'dijkstra2' example, for example, becomes much faster.
+- Added `--boost` option, to use boost containers. This can help when using dictionaries/sets or many very short lists. The 'dijkstra2' example, for example, becomes much faster.
 
-- Added `--predict` option, which tries to predict maximum list sizes before
-  (re)allocating storage, based on run-time sampling per allocation site. This
-  can greatly improve performance if reallocation is the bottleneck.
+- Added `--predict` option, which tries to predict maximum list sizes before (re)allocating storage, based on run-time sampling per allocation site. This can greatly improve performance if reallocation is the bottleneck.
 
 - Catching up with Python 3.x features:
+
   - Support `min/max(default)`
+
   - Support `time.{time_ns, perf_counter[_ns], monotonic[_ns], process_time[_ns]}`
+
   - Support `math.{ulp, nextafter, remainder}`
+
   - Support `str/bytes.startswith/endswith(tuple)`
+
   - Support `str/bytes.maketrans/translate`
+
   - Support `glob.escape`
+
   - Support `base64.{b16encode, b16decode}`
+
   - Support `os.{scandir, cpu_count, fspath, replace}`
+
   - Support `tuple.{index, count}`
+
   - Support `socket.{getblocking, create_connection}`
+
   - Support `datetime.timedelta.total_seconds`
+
   - Support `os.path.{relpath, expanduser}`
 
 - Now raising ZeroDivisionError, can be disabled with `--nozero`
@@ -39,25 +45,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Several builtin arguments could not be passed by keyword (e.g. `sum(start=..)`)
+
 - Several `--int64`, `--float32` related fixes
+
 - Over 100 minor bugs uncovered (and fixed) by Claude
+
 - Sorting is now stable
+
 - Fixed several C++ compilation warnings
+
+- `range` lengths were computed in 32-bit arithmetic, so `len`, indexing, slicing, `list` and `reversed` all wrapped past `2 ** 31` on the (default) 64-bit int build
+
+- `str`/`hex`/`oct`/`bin` of the most negative int negated it first, which is undefined: `str(-2 ** 63)` printed `-0` and read outside the digit cache
+
+- `repr`/`str` of a float now print the shortest string that reads back as the same value, as CPython does, instead of a fixed 16 significant digits (`repr(2 ** 0.5)` lost its last digit). This is also considerably faster
+
+- `int.bit_length` was computed as `floor(log2(x)) + 1` in floating point and so was off by one near powers of two, e.g. for `2 ** 62 - 1`
+
+- `int ** negative-int` returned 1 rather than the float CPython gives. A negative *literal* exponent is now retyped as a float, so `10 ** -1` and `pow(10, -1)` give `0.1` as in CPython, while `2 ** 3` stays an int. When the exponent is not a literal its sign is unknown at compile time, and there the existing warning still applies and a `ValueError` is raised at run time rather than silently answering wrongly
+
+- `'%s' % None` emitted a bare `NULL` whose deduced type had no formatting overload, so the generated C++ did not compile
 
 ### Optimized
 
 - Iteration over generator expressions is now much faster
+
 - Optimized `sum/max/min(list-comprehension/generator-expression)`
 
 ### Changed
 
 - The default int size is now 64-bit (override with `--int32`)
+
 - Hash values now have the same type as the shedskin int type
 
 ### Development
 
 - Modernized type annotations (while still compatible with Python 3.9)
+
 - Improved type inference logging
+
 - Added many tests for previously untested features
 
 
@@ -66,84 +92,147 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Preliminary support for Python 3.15
+
 - Catching up with Python 3.x:
+
     - Added support for `int.from_bytes/to_bytes` (3.2, 3.11)
+
     - Added support for `math.integer` module (3.15)
+
     - Support `collections.deque(maxlen)` (3.1)
+
     - Updated `re` module support with changes in 3.x
+
     - Updated `heapq` module support with changes in 3.x
+
     - Updated `csv` module support with changes in 3.x
+
     - Added support for `collections.defaultdict` | and |= operators (3.9)
+
     - Added support for frozendict (3.15)
+
     - Added support for `math.{fmax, fmin, isnormal, issubnormal}` (3.15)
+
     - Added support for `float.hex/fromhex` (3.0)
+
 - Added/improved support for `__iter__` and `__call__` methods
+
 - Added support for `__complex__` method
 
 ### Fixed
 
 - Avoid creating empty Makefile when using --nomakefile (Davide Gessa)
+
 - Fixed dict comprehension code generation crash (`TypeError: 'Tuple' object is not subscriptable`) in `cpp.py` by accessing `node.elt.elts[0]`/`node.elt.elts[1]` instead of `node.elt[0]`/`node.elt[1]`
+
 - Fixed dict comprehension type inference in `graph.py`: `isinstance(node.elt, tuple)` was always `False` for `ast.Tuple` nodes, so key/value type constraints were never set up. Changed to `node in self.gx.dictcomp_to_lc.values()`
+
 - Fixed `runtests --run` executing unbuilt ext tests by aligning ctest regex with the build target suffix in `cmake.py`
+
 - Added missing `WORKING_DIRECTORY` for non-Windows ext tests in CMake configuration
+
 - Much improved progress bar for larger/OO-heavy programs
+
 - Fixed exception messages for extension modules
+
 - Fixed escaping in string/bytes literals
+
 - Fix for -s/--silent
+
 - Exporting of methods called via inheritance in extension modules
+
 - Make `__ifloordiv__` fall back to `__floordiv__`
+
 - Allow magic methods to be virtualized
+
 - Fix for `for in defaultdict.items()`
+
 - Fix for set equality
+
 - Fix for set iteration
+
 - Fix for slice assignment with iterable
+
 - Remove module path from `__class__.__name__`
+
 - Fallback to `__index__` for ints/floats in some (but not all) cases
+
 - Support `array.array(q/Q)`
+
 - Fix for `copy.deepcopy` (forgot to pass memo dict)
+
 - Fix for virtual methods (base class method is called, but only via inheritance)
+
 - Fix round() tie-break
+
 - Fix `bytearray.__class__`
+
 - Many other minor fixes
+
 - Many GCC warnings
 
 ### Optimized
 
 - random number generation now uses Xoshiro engine (many times faster)
+
 - added cache for 2-len tuples containing small integers (-20..20)
+
 - cache 0-len string
+
 - str/bytes.startswith/endswith
+
 - str.strip
+
 - list(range)
+
 - reserve some space for empty lists (in the future this will be done by the STL)
+
 - avoid list creation when unpacking
+
 - list.index
+
 - list(sequence)
+
 - str/bytes.find
+
 - list(dict/bytes)
+
 - set.update
+
 - iterating over file
 
 ### Tests
 
 - Cleaned up unit tests: removed 46 duplicate/trivial tests across test files, consolidated GlobalInfo property tests into `test_config.py`
+
 - Replaced unnecessary mocks with real objects in `test_virtual.py` (MagicMock call nodes -> ast.Call, MagicMock modules -> python.Module)
+
 - Removed unused MagicMock import from `test_typestr.py`, unused `io` import from `test_cpp.py`
+
 - Added unit tests for graph.py helpers: `_const_str`, `register_node`, `slice_nums`, `get_arg_nodes`, `has_star_kwarg`, `make_arg_list`, `struct_faketuple`
+
 - Added unit tests for typestr.py: `nodetypestr` looper/wopper paths, `typestr` error fallback, `dynamic_variable_error`, `typestrnew` anonymous functions/templates/bytes+str mix/ExtmodError, `incompatible_assignment_rec` recursion
+
 - Added pipeline integration tests (`test_pipeline.py`) driven by a demo program (`tests/unit/fixtures/demo_program1.py`) that exercises parsing, type inference, virtual analysis, and C++ code generation end-to-end
+
 - Coverage improvements for core modules: infer.py 14%->84%, cpp.py 8%->53%, virtual.py 27%->90%, typestr.py 57%->88%, graph.py 45%->63%
 
 ### Changed
 
 - Converted build system to uv, replacing pip/setuptools workflow with `uv` commands in Makefile (`f97db27a`)
+
 - Applied mypy strict mode fixes across core modules (`__init__`, `cmake`, `config`, `cpp`, `graph`, `infer`, `makefile`, `stats`) (`635c2938`)
+
 - Converted documentation from Sphinx/RST to MkDocs with Markdown (`23c5c338`)
+
   - Replaced `README.rst` with `README.md`
+
   - Removed generated Sphinx HTML/JS/CSS assets from `docs/`
+
   - Added `mkdocs.yml` configuration
+
 - Updated `Makefile` test target to fix test invocation (`7cebb2ff`)
+
   - Refactored `graph.py` and `infer.py` to resolve type issues
 
 ### Removed
@@ -155,20 +244,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Local dependency management (`--local-deps` flag) with bundled zip archives:
+
   - Builds bdwgc and pcre2 from compressed sources in `shedskin/ext/`
+
   - Extracts to platform-specific cache on first use:
+
     - macOS: `~/Library/Caches/shedskin/`
+
     - Linux: `~/.cache/shedskin/`
+
     - Windows: `%LOCALAPPDATA%/shedskin/Cache/`
+
   - Caches built static libraries for subsequent compilations
+
   - Works completely offline (no network required)
+
   - Cross-platform support (Linux, macOS, Windows)
+
 - `LocalDependencyManager` class in `cmake.py` for zip-based dependency building
+
 - CLI option `--local-deps` for both `translate` (Makefile) and `build` (CMake) commands
+
 - Unit tests for core modules (`tests/unit/`, 74 tests total):
+
   - `test_config.py`: Tests for GlobalInfo and state objects
+
   - `test_graph.py`: Tests for constraint graph building
+
   - `test_infer.py`: Tests for type inference
+
   - `test_cpp.py`: Tests for C++ code generation config
 
 - Initial tracked release
@@ -176,56 +280,93 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Made `--local-deps` the default dependency manager for `build`, `run`, and `runtests` subcommands
+
   - Dependencies are now automatically built from bundled `ext/` sources
+
   - No external package manager required out of the box
+
 - Simplified CMake output directories to `${CMAKE_BINARY_DIR}` (executables in `build/`)
+
 - Bundled bdwgc (v8.2.10) and pcre2 (pcre2-10.47) sources as compressed zip archives in `ext/`:
+
   - Reduced from 25MB (full sources) to 1.2MB (trimmed and compressed)
+
   - Removed documentation, tests, CI/CD files, autotools, legacy platform support
+
   - Removed SLJIT (JIT compiler) from pcre2 as shedskin doesn't use JIT features
+
 - Refactored `GlobalInfo` class into focused state objects for better code organization:
+
   - `FileSystemPaths`: Immutable paths for shedskin installation, resources, and libraries
+
   - `BuildConfiguration`: Build flags (bounds_checking, int32/64, nogc, etc.)
+
   - `NamingContext`: C++ keywords, prefix, and builtin type names
+
   - `EntityRegistry`: Functions, classes, variables, modules, and inheritance tracking
+
   - `GraphBuildingContext`: Temporary graph building state (loops, comprehensions, etc.)
+
   - `TypeInferenceState`: Core type inference data (cnode, types, constraints, etc.)
+
 - Created new `shedskin/state/` package containing the focused state dataclasses
+
 - Maintained 100% backwards compatibility via property delegation in `GlobalInfo`
+
 - Consolidated CLI argument definitions using argparse parent parsers:
+
   - Created `_create_shared_parsers()` method with reusable argument groups
+
   - Shared parsers: `stats`, `types`, `disable`, `compiler`, `cmake`
+
   - Reduced code duplication across `translate`, `build`, `run`, `runtests` subcommands
 
 ### Security
 
 - Replaced `os.system()` with `subprocess.run()` across all modules:
+
   - `cmake.py`: shellcmd, cmake config/build/test, pytest
+
   - `makefile.py`: Command execution in `_execute()`
+
   - `__init__.py`: Executable running and Windows color output hack
 
 ### Documentation
 
 - Documented type inference tuning constants in `infer.py`:
+
   - `INCREMENTAL`: Enable incremental analysis mode
+
   - `INCREMENTAL_FUNCS`: Functions to add per round (default: 5)
+
   - `INCREMENTAL_DATA`: Enable incremental allocation tracking
+
   - `INCREMENTAL_ALLOCS`: Allocations before restart (default: 1)
+
   - `MAXITERS`: Maximum iterations per round (default: 30)
+
   - `CPA_LIMIT`: Initial cartesian product limit (default: 10)
+
 - Added `MAX_TYPE_DEPTH` constant in `typestr.py` for recursion limit (default: 10)
 
 ### Fixed
 
 - Fixed CMake build failure when source file path is absolute (e.g., building from a different directory with `../examples/foo.py`). The issue occurred because absolute parent paths were being concatenated with build directories, creating invalid paths like `build/exe/C:/Users/.../file.cpp`.
+
 - Resource leaks: Added context manager support to `MakefileWriter` class
+
 - File handling: Use context managers for file operations in `config.py`
 
 ### Removed
 
 - Removed Conan dependency manager support:
+
   - Removed `--conan` CLI option
+
   - Removed `ConanBDWGC`, `ConanPCRE`, and `ConanDependencyManager` classes
+
   - Removed `ENABLE_CONAN` CMake option
+
   - Removed `shedskin/resources/conan/` directory
+
   - Removed conan from `requirements.txt`

--- a/shedskin/ast_utils.py
+++ b/shedskin/ast_utils.py
@@ -29,7 +29,7 @@ Note that ast.unparse can be very useful during debugging.
 """
 
 import ast
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from . import config
 
@@ -77,6 +77,44 @@ def is_none(node: ast.AST) -> bool:
         if isinstance(node, ast.Constant) and node.value is None:
             return True
     return False
+
+
+def negative_num_value(node: ast.AST) -> Optional[Union[int, float]]:
+    """Value of a syntactically negative numeric literal, else None.
+
+    '-1' parses as UnaryOp(USub, Constant(1)) rather than Constant(-1), so both
+    spellings have to be recognized.
+    """
+    if isinstance(node, ast.Constant):
+        value = node.value
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            if value < 0:
+                return value
+    elif isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        operand = node.operand
+        if isinstance(operand, ast.Constant):
+            negated = operand.value
+            if isinstance(negated, (int, float)) and not isinstance(negated, bool):
+                if negated > 0:
+                    return -negated
+    return None
+
+
+def float_negative_exponent(node: ast.expr) -> ast.expr:
+    """Retype a negative int literal exponent as the equivalent float.
+
+    'int ** int' is typed as int, but python returns a float when the exponent
+    is negative: 10 ** -1 is 0.1. That depends on the exponent's *value*, which
+    inference cannot see -- except for a literal, where the sign is right
+    there. Handing back a float literal gives exactly python's result via
+    'int_ ** float_', and matches how cpython itself defers to float pow here.
+    Anything else is returned unchanged, including an already-float literal, so
+    this is safe to apply more than once.
+    """
+    value = negative_num_value(node)
+    if isinstance(value, int):
+        return ast.copy_location(ast.Constant(value=float(value)), node)
+    return node
 
 
 def is_literal(node: ast.AST) -> bool:

--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -4231,8 +4231,20 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
         # --- visit nodes, boxing scalars
         self.visitm("__mod6(", node.left, ", ", str(len(nodes)), func)
         for n in nodes:
-            self.visitm(", ", n, func)
+            self.append(", ")
+            # __mod6 is variadic, so a bare NULL argument would be deduced as
+            # whatever integer type NULL happens to be spelled as (long on
+            # some platforms, which has no __str/repr overload). Give the
+            # argument the pointer type those overloads are declared for.
+            if self.is_none_type(n):
+                self.append("((void *)0)")
+            else:
+                self.visit(n, func)
         self.append(")")
+
+    def is_none_type(self, node: ast.AST) -> bool:
+        """Whether a node's inferred type is exactly None"""
+        return self.mergeinh.get(node) == {(python.def_class(self.gx, "none"), 0)}
 
     def attr_var_ref(
         self, node: ast.Attribute, ident: str

--- a/shedskin/graph.py
+++ b/shedskin/graph.py
@@ -1415,6 +1415,8 @@ class ModuleVisitor(ast_utils.BaseNodeVisitor):
                 func,
             )
         elif isinstance(node.op, ast.Pow):
+            if not getmv().module.builtin:
+                node.right = ast_utils.float_negative_exponent(node.right)
             self.fake_func(node, node.left, "__pow__", [node.right], func)
         elif isinstance(node.op, ast.Mod):
             if isinstance(node.right, ast.Tuple):
@@ -2339,6 +2341,12 @@ class ModuleVisitor(ast_utils.BaseNodeVisitor):
                     mv=getmv(),
                     warning=True,
                 )
+
+            # pow(10, -1) should agree with 10 ** -1, see visit_BinOp. Only the
+            # two-argument form: three-argument pow is modular exponentiation.
+            if ident == "pow" and not getmv().module.builtin:
+                if len(node.args) == 2 and not node.keywords:
+                    node.args[1] = ast_utils.float_negative_exponent(node.args[1])
 
             # optimize sum/max/min(listcomp-or-genexpr)
             if ident in ("sum", "min", "max") and not getmv().module.builtin:

--- a/shedskin/lib/builtin.hpp
+++ b/shedskin/lib/builtin.hpp
@@ -102,6 +102,20 @@ inline void operator delete[](void *, std::align_val_t,
 #include <limits>
 #include <numeric>
 #include <cstddef>
+#include <type_traits>
+#include <bit>
+#include <charconv>
+#include <cstdio>
+#include <cstdlib>
+
+/* Floating-point std::to_chars is C++17, but shipped later than the rest of
+ * <charconv>: libstdc++ has it from release 11, while libc++ and MSVC have it
+ * but libc++ still does not advertise __cpp_lib_to_chars, so that macro cannot
+ * be used to detect it. Anything older falls back to probing printf
+ * precisions, which reaches the same answer more slowly. */
+#if !defined(__GLIBCXX__) || (_GLIBCXX_RELEASE >= 11)
+#define __SS_FP_TO_CHARS 1
+#endif
 
 
 #ifndef WIN32
@@ -134,6 +148,19 @@ namespace __shedskin__ {
 #endif
 #define __SS_LONG
 #endif
+
+/* Unsigned counterpart of __ss_int. Signed overflow is undefined behaviour,
+ * so anything that has to negate a possibly-most-negative value, count bits,
+ * or compute a difference that may exceed the signed range does the work in
+ * this type instead, where wrap-around is well defined. */
+typedef std::make_unsigned<__ss_int>::type __ss_uint;
+
+/* Magnitude of an __ss_int as __ss_uint. Written as a subtraction from zero
+ * rather than as -(__ss_uint)i so that the most negative value (whose
+ * negation is not representable as __ss_int) is handled correctly. */
+static inline __ss_uint __ss_magnitude(__ss_int i) {
+    return (i < 0) ? ((__ss_uint)0 - (__ss_uint)i) : (__ss_uint)i;
+}
 
 /* float type */
 
@@ -566,7 +593,7 @@ template<class T, int SiteId> list<T> *__ss_list() {
 
 inline list<__ss_int> *__ss_list_range(__ss_int a, __ss_int b, __ss_int c) {
     list<__ss_int> *l = new list<__ss_int>();
-    __ss_int len = range_len((int)a, (int)b, (int)c);
+    __ss_int len = range_len(a, b, c);
     l->units.resize(len);
     __ss_int pos = 0;
     if(a <= b) {

--- a/shedskin/lib/builtin/function.cpp
+++ b/shedskin/lib/builtin/function.cpp
@@ -76,21 +76,23 @@ template<> __ss_int id(__ss_bool) { throw new TypeError(new str("'id' called wit
 
 /* range */
 
-int range_len(int lo, int hi, int step) {
-    /* modified from CPython */
-    int n = 0;
+__ss_int range_len(__ss_int lo, __ss_int hi, __ss_int step) {
+    /* modified from CPython. The intermediate difference is computed in
+     * __ss_uint because hi-lo can exceed the signed range even when the
+     * resulting length does not. */
+    __ss_int n = 0;
     if ((lo < hi) && (step>0)) {
-        unsigned int uhi = (unsigned int)hi;
-        unsigned int ulo = (unsigned int)lo;
-        unsigned int diff = uhi - ulo - 1;
-        n = (int)(diff / (unsigned int)step + 1);
+        __ss_uint uhi = (__ss_uint)hi;
+        __ss_uint ulo = (__ss_uint)lo;
+        __ss_uint diff = uhi - ulo - 1;
+        n = (__ss_int)(diff / (__ss_uint)step + 1);
     }
     else {
         if ((lo > hi) && (step<0)) {
-            unsigned int uhi = (unsigned int)lo;
-            unsigned int ulo = (unsigned int)hi;
-            unsigned int diff = uhi - ulo - 1;
-            n = (int)(diff / (unsigned int)(-step) + 1);
+            __ss_uint uhi = (__ss_uint)lo;
+            __ss_uint ulo = (__ss_uint)hi;
+            __ss_uint diff = uhi - ulo - 1;
+            n = (__ss_int)(diff / __ss_magnitude(step) + 1);
         }
     }
     return n;
@@ -156,7 +158,7 @@ __iter<__ss_int> *__xrange::__iter__() {
 }
 
 __ss_int __xrange::__len__() {
-    return range_len((int)a, (int)b, (int)s);
+    return range_len(a, b, s);
 }
 
 __ss_int __xrange::__getitem__(__ss_int i) {
@@ -230,7 +232,7 @@ __xrange *range(__ss_int a, __ss_int b, __ss_int s) { return new __xrange(a,b,s)
 __xrange *range(__ss_int n) { return new __xrange(0, n, 1); }
 
 __iter<__ss_int> *reversed(__xrange *x) {
-   return new __rangeiter(x->a+(range_len((int)x->a,(int)x->b,(int)x->s)-1)*x->s, x->a-x->s, -x->s);
+   return new __rangeiter(x->a+(range_len(x->a,x->b,x->s)-1)*x->s, x->a-x->s, -x->s);
 }
 
 /* repr */

--- a/shedskin/lib/builtin/function.hpp
+++ b/shedskin/lib/builtin/function.hpp
@@ -51,6 +51,7 @@ str *__str(int t, int base=10);
 str *__str(__ss_bool b);
 str *__str(void *);
 str *__str();
+str *__str_abs(__ss_int t, __ss_int base); /* digits of |t|, no sign */
 
 /* abs */
 
@@ -880,9 +881,9 @@ template<class T> str *bin(T t) {
 
 template<> inline str *bin(__ss_int i) {
     if(i<0)
-        return (new str("-0b"))->__add__(__str(-i, (__ss_int)2));
+        return (new str("-0b"))->__add__(__str_abs(i, (__ss_int)2));
     else
-        return (new str("0b"))->__add__(__str(i, (__ss_int)2));
+        return (new str("0b"))->__add__(__str_abs(i, (__ss_int)2));
 }
 
 template<>
@@ -920,9 +921,9 @@ template<class T> str *hex(T t) {
 
 template<> inline str *hex(__ss_int i) {
     if(i<0)
-        return (new str("-0x"))->__add__(__str(-i, (__ss_int)16));
+        return (new str("-0x"))->__add__(__str_abs(i, (__ss_int)16));
     else
-        return (new str("0x"))->__add__(__str(i, (__ss_int)16));
+        return (new str("0x"))->__add__(__str_abs(i, (__ss_int)16));
 }
 
 template<> inline str *hex(__ss_bool i) {
@@ -937,9 +938,9 @@ template<class T> str *oct(T t) {
 
 template<> inline str *oct(__ss_int i) {
     if(i<0)
-        return (new str("-0o"))->__add__(__str(-i, (__ss_int)8));
+        return (new str("-0o"))->__add__(__str_abs(i, (__ss_int)8));
     else
-        return (new str("0o"))->__add__(__str(i, (__ss_int)8));
+        return (new str("0o"))->__add__(__str_abs(i, (__ss_int)8));
 }
 
 template<> inline str *oct(__ss_bool i) {
@@ -1050,7 +1051,7 @@ inline __ss_bool __ss_in_range(__ss_int i, __ss_int a) {
 
 /* range_len */
 
-int range_len(int lo, int hi, int step);
+__ss_int range_len(__ss_int lo, __ss_int hi, __ss_int step);
 
 #endif
 #endif

--- a/shedskin/lib/builtin/math.hpp
+++ b/shedskin/lib/builtin/math.hpp
@@ -29,6 +29,12 @@ template<> inline __ss_float __power(__ss_float a, __ss_float b) { __SS_POW_ZERO
 
 template<> inline __ss_int __power(__ss_int a, __ss_int b) {
     __SS_POW_ZERO_CHECK(a, b);
+    /* CPython returns a float here (2 ** -1 == 0.5), but the result type has
+     * already been fixed to int by then. The loop below would silently return
+     * its seed value of 1, so refuse instead of answering wrongly. Translation
+     * already warns when the exponent is a negative constant. */
+    if(b < 0)
+        throw new ValueError(new str("pow(int, int) with a negative exponent returns a float in python; use a float base (e.g. 2.0 ** -1)"));
     switch(b) {
         case 2: return a*a;
         case 3: return a*a*a;
@@ -235,6 +241,9 @@ inline __ss_bool __ss_is_integer(__ss_float d) {
 /* int.{bit_count, bit_length */
 
 namespace __int___ {
+    /* Deliberately counts the two's complement bit pattern rather than the
+     * magnitude CPython uses, so that negative values keep working as 64-bit
+     * masks (see the othello2 example and test_type_int.test_bit_count). */
     inline __ss_int bit_count(__ss_int i) {
 #ifdef __SS_LONG
         return (__ss_int)std::bitset<std::numeric_limits<unsigned long long>::digits>((unsigned long long)i).count(); // TODO hard-coded types
@@ -243,11 +252,21 @@ namespace __int___ {
 #endif
     }
 
+    /* Deliberately not floor(log2(i))+1: converting a wide integer to double
+     * rounds, so 2**62-1 came out of log2 as exactly 62.0 and reported a bit
+     * length of 63 rather than 62. std::bit_width is exact at every width, and
+     * compiles to a single count-leading-zeros instruction. */
     inline __ss_int bit_length(__ss_int i) {
-        if(i == 0)
-            return 0;
-        return (__ss_int)(std::floor(std::log2(std::abs(i)))) + 1;
-        //return (__ss_int)std::bit_width(i); // TODO available from C++20
+        __ss_uint u = __ss_magnitude(i);
+#ifdef __SS_INT128
+        /* bit_width takes a standard unsigned type, which __int128 is not */
+        __ss_int n = 0;
+        for(; u; u >>= 1)
+            n++;
+        return n;
+#else
+        return (__ss_int)std::bit_width((unsigned long long)u);
+#endif
     }
 
 /*    inline tuple<__ss_int> *as_integer_ratio(__ss_int i) {

--- a/shedskin/lib/builtin/str.cpp
+++ b/shedskin/lib/builtin/str.cpp
@@ -855,33 +855,33 @@ PyObject *str::__to_py__() {
 }
 #endif
 
-#ifdef __SS_LONG
-str *__str(__ss_int i, __ss_int base) {
-    if(i<10 && i>=0 && base==10)
-        return __char_cache[((unsigned char)('0'+i))];
-    char buf[70];
-    char *psz = buf+69;
-/*    if(i==INT_MIN)
-        return new str("-2147483648"); */
-    int neg = i<0;
+/* Digits are generated from the magnitude held in an unsigned type rather
+ * than by negating a signed one: the most negative value of any signed type
+ * has no representable negation, so "if(neg) i = -i;" left it negative and
+ * then indexed __str_cache out of bounds (str(-2**63) printed "-0"). The
+ * buffer is sized from the type so that even base 2 cannot overflow it. */
+template<class U> static str *__str_digits(U u, U ubase, bool neg) {
+    const size_t bufsize = 8*sizeof(U)+4;
+    char buf[bufsize];
+    char *psz = buf+bufsize-1;
     *psz = 0;
-    if(neg) i = -i;
-    if(base == 10) {
-        __ss_int pos;
-        while(i > 999) {
-            pos = 4*(i%1000);
-            i = i/1000;
+
+    if(ubase == 10) {
+        U pos;
+        while(u > 999) {
+            pos = 4*(u%1000);
+            u = u/1000;
             *(--psz) = __str_cache[pos];
             *(--psz) = __str_cache[pos+1];
             *(--psz) = __str_cache[pos+2];
         }
-        pos = 4*i;
-        if(i>99) {
+        pos = 4*u;
+        if(u>99) {
             *(--psz) = __str_cache[pos];
             *(--psz) = __str_cache[pos+1];
             *(--psz) = __str_cache[pos+2];
         }
-        else if(i>9) {
+        else if(u>9) {
             *(--psz) = __str_cache[pos];
             *(--psz) = __str_cache[pos+1];
         }
@@ -889,53 +889,37 @@ str *__str(__ss_int i, __ss_int base) {
             *(--psz) = __str_cache[pos];
     }
     else do {
-        *(--psz) = "0123456789abcdefghijklmnopqrstuvwxyz"[i%base];
-        i = i/base;
-    } while(i);
+        *(--psz) = "0123456789abcdefghijklmnopqrstuvwxyz"[u%ubase];
+        u = u/ubase;
+    } while(u);
     if(neg) *(--psz) = '-';
-    return new str(psz, buf+69-psz);
+    return new str(psz, (size_t)(buf+bufsize-1-psz));
+}
+
+template<class T> static str *__str_signed(T i, T base) {
+    typedef typename std::make_unsigned<T>::type U;
+    U u = (i < 0) ? ((U)0 - (U)i) : (U)i;
+    return __str_digits<U>(u, (U)base, i < 0);
+}
+
+#ifdef __SS_LONG
+str *__str(__ss_int i, __ss_int base) {
+    if(i<10 && i>=0 && base==10)
+        return __char_cache[((unsigned char)('0'+i))];
+    return __str_signed<__ss_int>(i, base);
 }
 #endif
 
 str *__str(int i, int base) {
     if(base==10 && i<10 && i>=0)
         return __char_cache[((unsigned char)('0'+i))];
+    return __str_signed<int>(i, base);
+}
 
-    char buf[70];
-    char *psz = buf+69;
-    if(base==10 and i==INT_MIN)
-        return new str("-2147483648");
-    int neg = i<0;
-    *psz = 0;
-    if(neg) i = -i;
-    if(base == 10) {
-        int pos;
-        while(i > 999) {
-            pos = 4*(i%1000);
-            i = i/1000;
-            *(--psz) = __str_cache[pos];
-            *(--psz) = __str_cache[pos+1];
-            *(--psz) = __str_cache[pos+2];
-        }
-        pos = 4*i;
-        if(i>99) {
-            *(--psz) = __str_cache[pos];
-            *(--psz) = __str_cache[pos+1];
-            *(--psz) = __str_cache[pos+2];
-        }
-        else if(i>9) {
-            *(--psz) = __str_cache[pos];
-            *(--psz) = __str_cache[pos+1];
-        }
-        else
-            *(--psz) = __str_cache[pos];
-    }
-    else do {
-        *(--psz) = "0123456789abcdefghijklmnopqrstuvwxyz"[i%base];
-        i = i/base;
-    } while(i);
-    if(neg) *(--psz) = '-';
-    return new str(psz, (size_t)(buf+69-psz));
+/* Unsigned digits of |i|, for bin/hex/oct: those prepend their own "-" and
+ * used to pass -i, which is undefined for the most negative value. */
+str *__str_abs(__ss_int i, __ss_int base) {
+    return __str_digits<__ss_uint>(__ss_magnitude(i), (__ss_uint)base, false);
 }
 
 str *__str(__ss_bool b) {
@@ -945,16 +929,81 @@ str *__str(__ss_bool b) {
 
 str *__str() { return new str(""); } /* XXX optimize */
 
+/* Shortest round-tripping decimal digits of a finite, non-negative t, written
+ * NUL-terminated into digits[] with no sign and no decimal point. Returns
+ * decpt: how many of those digits belong before the decimal point, so that
+ * the value is 0.<digits> * 10**decpt. */
+static int __float_digits(__ss_float t, char *digits) {
+    char sci[64];
+#ifdef __SS_FP_TO_CHARS
+    std::to_chars_result r =
+        std::to_chars(sci, sci+sizeof(sci)-1, t, std::chars_format::scientific);
+    *r.ptr = 0;
+#else
+    /* The first precision that reads back bit-identical is by construction
+     * the shortest round-tripping one. */
+    for(int prec = 0; ; prec++) {
+        snprintf(sci, sizeof(sci), "%.*e", prec, (double)t);
+        if(prec >= 17 || (__ss_float)strtod(sci, NULL) == t)
+            break;
+    }
+#endif
+    /* split "d[.ddd]e[+-]dd" into bare digits and a decimal exponent */
+    const char *e = strchr(sci, 'e');
+    if(!e) /* neither producer can omit the exponent; do not walk off the end */
+        e = sci + strlen(sci);
+    int exp10 = *e ? (int)strtol(e+1, NULL, 10) : 0;
+    size_t n = 0;
+    for(const char *p = sci; p < e; p++)
+        if(*p != '.')
+            digits[n++] = *p;
+    while(n > 1 && digits[n-1] == '0') /* only reachable via the fallback */
+        n--;
+    digits[n] = 0;
+    return exp10 + 1;
+}
+
+/* CPython's repr and str of a float are the same function, and both print the
+ * shortest decimal string that reads back as the identical double. The former
+ * implementation here asked a stringstream for 16 significant digits, which is
+ * neither shortest nor always sufficient -- 17 are needed in the worst case --
+ * so e.g. repr(2**0.5) came out as 1.414213562373095, a *different* double
+ * from the one being printed. */
 template<> str *__str(__ss_float t) {
-    std::stringstream ss;
-    ss.precision(16);
-    ss << std::showpoint << t;
-    __GC_STRING s = ss.str().c_str();
-    if(s.find('e') == std::string::npos)
-    {
-        size_t j = s.find_last_not_of("0");
-        if( s[j] == '.') j++;
-        s = s.substr(0, j+1);
+    if(std::isnan(t))
+        return new str("nan");
+    if(std::isinf(t))
+        return new str(t < 0 ? "-inf" : "inf");
+
+    char digits[40];
+    int decpt = __float_digits(std::fabs(t), digits);
+    int ndigits = (int)strlen(digits);
+
+    __GC_STRING s;
+    if(std::signbit(t)) /* not t < 0: -0.0 prints as -0.0 */
+        s += '-';
+
+    if(decpt <= -4 || decpt > 16) { /* CPython's fixed/scientific cutoffs */
+        s += digits[0];
+        if(ndigits > 1) {
+            s += '.';
+            s.append(digits+1, (size_t)(ndigits-1));
+        }
+        char ebuf[16];
+        snprintf(ebuf, sizeof(ebuf), "e%+03d", decpt-1);
+        s += ebuf;
+    } else if(decpt <= 0) {
+        s += "0.";
+        s.append((size_t)(-decpt), '0');
+        s += digits;
+    } else if(decpt >= ndigits) {
+        s += digits;
+        s.append((size_t)(decpt-ndigits), '0');
+        s += ".0";
+    } else {
+        s.append(digits, (size_t)decpt);
+        s += '.';
+        s += digits+decpt;
     }
     return new str(s);
 }

--- a/tests/test_builtins/test_builtins.py
+++ b/tests/test_builtins/test_builtins.py
@@ -360,6 +360,24 @@ def test_range():
     assert r.index(3) == 1
 
 
+def test_range_beyond_32_bits():
+    # range lengths used to be computed in 32-bit arithmetic, so anything past
+    # 2 ** 31 wrapped: len() returned 705032704 here and indexing raised
+    big = 5000000000
+
+    assert len(range(0, big)) == big
+    assert len(range(big, 0, -1)) == big
+    assert range(0, big)[3000000000] == 3000000000
+    assert range(0, big)[-1] == big - 1
+    assert len(range(0, big, 3)) == 1666666667
+
+    assert list(range(4000000000, 4000000003)) == [4000000000, 4000000001, 4000000002]
+    assert list(reversed(range(4000000000, 4000000003))) == [4000000002, 4000000001, 4000000000]
+
+    assert 4000000000 in range(0, big)
+    assert list(range(0, big)[3000000000:3000000003]) == [3000000000, 3000000001, 3000000002]
+
+
 def test_range_slicing():
     r = range(2,20,2)
     assert list(r[2:4:3]) == [6]
@@ -475,6 +493,7 @@ def test_all():
     test_property()
     test_print()
     test_range()
+    test_range_beyond_32_bits()
     test_range_slicing()
     test_repr()
     test_reversed()

--- a/tests/test_ops_string/test_ops_string.py
+++ b/tests/test_ops_string/test_ops_string.py
@@ -82,12 +82,26 @@ def test_unterminated_mapping_key():
     assert ("%(aap)s" % d) == 'aapje'
 
 
+def test_none_argument():
+    # None used to be emitted as a bare NULL into the variadic formatting
+    # helper, where it was deduced as an integer type with no __str/repr
+    # overload rather than as a pointer, and the generated c++ did not compile
+    assert "%s" % None == 'None'
+    assert "%r" % None == 'None'
+    assert "[%s] [%s]" % (None, 3) == '[None] [3]'
+    assert "%s %s" % (None, None) == 'None None'
+
+    x = None
+    assert "%s" % x == 'None'
+
+
 def test_all():
     test_classic1()
     test_classic2()
     test_classic3()
     test_str_precision()
     test_unterminated_mapping_key()
+    test_none_argument()
 
 
 if __name__ == "__main__":

--- a/tests/test_type_float/test_type_float.py
+++ b/tests/test_type_float/test_type_float.py
@@ -77,6 +77,43 @@ def test_hex_fromhex():
     assert float.fromhex(s) == 17.123
 
 
+def test_repr_roundtrip():
+    # repr must print the shortest decimal string that reads back as the very
+    # same double; a fixed 16 significant digits is neither shortest nor always
+    # enough, and dropped the last digit of e.g. 2 ** 0.5
+    for x in [0.1, 1 / 3, 2 ** 0.5, 0.1 + 0.2, 1e300, 5e-324, 1e-320,
+              1.2345678901234568e+17, -2.5, 100.0, 0.0, -0.0]:
+        assert float(repr(x)) == x
+
+    assert repr(2 ** 0.5) == '1.4142135623730951'
+    assert repr(0.1) == '0.1'
+    assert repr(0.1 + 0.2) == '0.30000000000000004'
+    assert repr(1.2345678901234568e+17) == '1.2345678901234568e+17'
+
+
+def test_repr_formatting():
+    # str and repr of a float are the same function, and the switch between
+    # fixed and scientific notation happens at these exact points
+    assert repr(1e15) == '1000000000000000.0'
+    assert repr(1e16) == '1e+16'
+    assert repr(0.0001) == '0.0001'
+    assert repr(1e-05) == '1e-05'
+
+    assert repr(0.0) == '0.0'
+    assert repr(-0.0) == '-0.0'
+    assert repr(1.0) == '1.0'
+    assert repr(-2.5) == '-2.5'
+    assert repr(1e100) == '1e+100'
+    assert repr(1e-320) == '1e-320'
+
+    assert str(1.0) == repr(1.0)
+    assert str(1e16) == repr(1e16)
+
+    assert repr(float('inf')) == 'inf'
+    assert repr(float('-inf')) == '-inf'
+    assert repr(float('nan')) == 'nan'
+
+
 def test_all():
     test_float()
     test_inf()
@@ -85,6 +122,8 @@ def test_all():
     test_division()
     test_multiplication()
     test_hex_fromhex()
+    test_repr_roundtrip()
+    test_repr_formatting()
 
 
 if __name__ == "__main__":

--- a/tests/test_type_int/test_type_int.py
+++ b/tests/test_type_int/test_type_int.py
@@ -63,10 +63,57 @@ def test_bit_length():
     assert (8).bit_length() == 4
     assert (123456).bit_length() == 17
 
+    # a float-based floor(log2(x))+1 rounds the argument on the way in and
+    # reports 63 for the first of these, and 64 for the last
+    assert (4611686018427387903).bit_length() == 62
+    assert (4611686018427387904).bit_length() == 63
+    assert (9223372036854775807).bit_length() == 63
+    assert (-9223372036854775807 - 1).bit_length() == 64
+
 
 def test_bit_count():
     assert (15).bit_count() == 4
 #    assert (-15).bit_count() == 4  # in shedskin, we assume unsigned, otherwise hard to use for bitmasking..? (othelloN example) # TODO add warning
+
+
+def test_power():
+    assert 2 ** 3 == 8
+    assert 2 ** 0 == 1
+    assert 10 ** 2 == 100
+    assert pow(2, 10) == 1024
+
+    # a negative exponent makes python return a float, so shedskin retypes a
+    # negative *literal* exponent to keep the result (and its type) the same;
+    # 2 ** 3 must stay an int, so this cannot simply always be a float
+    assert 10 ** -1 == 0.1
+    assert 2 ** -1 == 0.5
+    assert 2 ** -3 == 0.125
+    assert pow(10, -1) == 0.1
+    assert (2 ** -1) + 0.25 == 0.75
+
+    assert 2.0 ** -1 == 0.5
+    assert 2.0 ** 2 == 4.0
+
+    # exponents that are not literals stay int ** int, where shedskin has no
+    # value to inspect; it raises rather than returning a wrong int
+    e = 3
+    assert 2 ** e == 8
+
+
+def test_str_extremes():
+    # the most negative int has no representable negation, so formatting it by
+    # negating first used to walk off the front of the digit cache: str()
+    # produced "-0" and the bin/hex/oct prefixes came out doubly signed
+    assert str(-9223372036854775807 - 1) == '-9223372036854775808'
+    assert str(9223372036854775807) == '9223372036854775807'
+    assert hex(-9223372036854775807 - 1) == '-0x8000000000000000'
+    assert oct(-9223372036854775807 - 1) == '-0o1000000000000000000000'
+    assert bin(-9223372036854775807 - 1) == '-0b' + '1' + '0' * 63
+
+    assert str(-1) == '-1'
+    assert hex(-255) == '-0xff'
+    assert oct(-8) == '-0o10'
+    assert bin(-10) == '-0b1010'
 
 
 def test_to_bytes():
@@ -149,6 +196,8 @@ def test_all():
     test_is_integer()
     test_bit_length()
     test_bit_count()
+    test_power()
+    test_str_extremes()
     test_to_bytes()
     test_from_bytes()
 


### PR DESCRIPTION
All six produced silently wrong answers (or, in the last case, uncompilable C++) on the default build. None were caught by the existing test suite; regression tests are added for each.

Every case below was verified by compiling a program and diffing its output against CPython. Checked on macOS/arm64 (AppleClang 21) with `--int32`, `--boost`, `--nogc` and `--nobounds --nowrap` in addition to the default configuration, all byte-identical to CPython. Also checked under `--float32`, where float output differs by design: `repr(2 ** 0.5)` is `1.4142135`, the shortest round-trip for a 32-bit float.

## The bugs

**`range` lengths were computed in 32-bit arithmetic.** `range_len()` took and returned `int` while `__ss_int` has defaulted to 64-bit since 0.9.9, so every caller narrowed on the way in. `len(range(0, 5000000000))` returned 705032704 (the value mod 2^32) and `range(0, 5000000000)[3000000000]` raised IndexError. Affected `len`, indexing, slicing, `list()` and `reversed()`. The value always fitted in `__ss_int`; only this helper narrowed it.

**`str`/`hex`/`oct`/`bin` of the most negative int.** All of them negated the value before generating digits, which is undefined for `INT64_MIN` --- it stays negative, and `__str_cache` was then indexed with a large negative offset. `str(-2**63)` printed `-0`. The 32-bit path had a guard for this in base 10 only, so `hex(INT_MIN)` was broken there too. Digits are now generated from an unsigned magnitude, which removes the special case entirely and cannot overflow at any width or base.

**Float `repr` did not round-trip.** The old implementation asked a `stringstream` for 16 significant digits, which is neither the shortest form CPython prints nor always sufficient (17 are needed in the worst case), so `repr(2 ** 0.5)` came out as `1.414213562373095` --- a *different* double from the one being printed. Now uses `std::to_chars` shortest round-trip digits plus CPython's fixed/scientific layout rules. Incidentally ~14x faster than the `stringstream` it replaces (150ms -> 10.6ms for 300k conversions).

**`int.bit_length()` was off by one near powers of two.** Computed as `floor(log2(abs(i))) + 1`; converting a wide integer to double rounds, so `2**62 - 1` reached `log2` as exactly `2**62` and reported 63 instead of 62. Now shifts, which is exact at every width and also well defined for `INT64_MIN` (where `std::abs` was UB).

**`int ** negative_int` returned 1.** Python returns a float here (`10 ** -1` is `0.1`), but that depends on the exponent's *value*: `int ** int` has to be typed as int, or `2 ** 10` would stop being usable as an index or a mask. The old code fixed the type to int and then returned the accumulator's seed value.

When the exponent is a **literal** the sign is visible at compile time, so nothing has to be guessed: it is now retyped as the equivalent float, which routes through `int_ ** float_` and yields exactly Python's result. This is also what CPython does internally, where `long_pow` defers to `float_pow` for negative exponents. Covers `10 ** -1`, `pow(10, -1)` and `x **= -1`; `2 ** 3` is untouched and still an int.

When the exponent is **not** a literal its sign is unknown until run time and there is no static answer. That case keeps the pre-existing translate-time warning and now raises `ValueError` rather than silently returning 1.

**`'%s' % None` generated uncompilable C++.** `None` was emitted as a bare `NULL` into the variadic `__mod6`, where it was deduced as whatever integer type `NULL` is spelled as --- `long` on macOS, which has no `__str`/`repr` overload --- and the build failed inside `builtin/function.hpp`. Now emitted as `((void *)0)`, matching the overloads that already exist for it.

## Performance

Each touched runtime path was benchmarked by translating once and building the same generated C++ twice, swapping only `SHEDSKIN_LIBDIR` between this branch and the pristine tree. Best of 7-11 runs on an idle machine.

| microbenchmark | before | after | change |
|---|---|---|---|
| `str(float)` x400k | 173.5ms | 32.8ms | **-81%** |
| `int.bit_length()` x3M | 11.9ms | 4.1ms | **-65%** |
| `range[i]` x3M | 9.8ms | 9.1ms | -8% |
| `hex`/`bin` x1M | 147.7ms | 147.8ms | +0.1% |
| `str(int)` x2M | 46.9ms | 48.3ms | +2.4% |

The two large wins are side effects of the correctness fixes: `std::to_chars` replaces a `stringstream`, and `std::bit_width` compiles to a single count-leading-zeros instruction where `floor(log2(...))+1` was a libm call.

The `str(int)` line is the one measurable cost, and it is not algorithmic: lifted out into a standalone A/B, the old and new digit routines are identical (103.5ms vs 103.0ms for 20M conversions), and `hex`/`bin` go through the very same new routine with no change. It appears to be code layout, `builtin.cpp` having grown. Left alone rather than chased.

Whole-program workloads are unaffected: list append -0.3%, dict ops 0.0%, recursive `fib` -0.1%, `nbody` 0.0%. Compile time of a generated program is +0.6% despite four added standard headers, which are largely pulled in transitively already.

## Deliberately not changed

`int.bit_count()` still counts the two's complement bit pattern rather than the magnitude CPython uses, so that negative values keep working as 64-bit masks (`examples/othello2`). That decision was already recorded in `test_type_int.test_bit_count`; a comment now records it at the implementation too.

## Testing

- `tests/unit`: 252 passed

- `shedskin runtests`: 218/218 passed (exe and ext)

- `pytest tests/` (the CPython oracle): +6 passing, same 31 pre-existing failures

- `mypy --strict`: same 7 pre-existing errors, none added

- `examples/nbody` output is byte-identical to a build against the pristine tree, confirming the float formatting change does not perturb `%`-formatted output (that path goes through `format.hpp`, not `__str`)

New tests live alongside the code they cover and pass under both CPython and Shed Skin: `test_type_int.test_power`, `test_type_int.test_str_extremes`, extra cases in `test_type_int.test_bit_length`, `test_builtins.test_range_beyond_32_bits`, `test_type_float.test_repr_roundtrip`, `test_type_float.test_repr_formatting`, and `test_ops_string.test_none_argument`.
