### PR TITLE
Build strings in place when a loop only appends to them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Optimized
 
+- Loops that only append to a local string (`out += ..` inside a `for`/`while`)
+  now build into a single buffer instead of reallocating and copying the whole
+  string every iteration, turning a quadratic loop into a linear one. Appending
+  200k times went from 11.2s to 4.6ms. The rewrite only applies where the
+  accumulator provably cannot be observed mid-loop; see `shedskin/strbuild.py`
 - random number generation now uses Xoshiro engine (many times faster)
 - added cache for 2-len tuples containing small integers (-20..20)
 - cache 0-len string

--- a/PR-dense-table.md
+++ b/PR-dense-table.md
@@ -1,0 +1,125 @@
+# Add opt-in open-addressing dict/set backend (`--dense-table`)
+
+**Suggested title:** Add opt-in open-addressing dict/set backend (ankerl::unordered_dense) **Suggested branch:** `dense-table`
+
+## Summary
+
+Adds an alternative, opt-in hash-table backend for `dict`/`set`. The default remains the long-standing chaining `std::unordered_map`/`std::unordered_set`; passing `--dense-table` (or the `ENABLE_DENSE_TABLE` CMake option) switches the `__GC_DICT`/`__GC_SET` typedefs to an open-addressing table (`ankerl::unordered_dense`), which stores entries densely in a contiguous vector for cache-friendly iteration and bulk operations.
+
+This addresses item 2 of the code-generation review (`REVIEW.md`, finding 3B.2): the chaining tables allocate one node per element and pointer-chase on every probe and traversal, which bounds dict/set-heavy programs regardless of what the generator emits.
+
+## Design
+
+- **Opt-in, not default.** The STL backend is untouched and remains the default, so existing builds are byte-for-byte unaffected. The open-addressing table is a deliberate, measured choice the user turns on.
+
+- **Single switch, three entry points.** One `dense_table` build-config flag drives all build paths:
+
+  - CLI: `shedskin --dense-table translate|build|run ...`
+
+  - Makefile backend: emits `-D__SS_DENSE_TABLE`
+
+  - CMake backend: sets the `ENABLE_DENSE_TABLE` option, which maps to the same `-D__SS_DENSE_TABLE` compile definition
+
+  - The macro `__SS_DENSE_TABLE` can also be defined directly.
+
+- **Guarded include.** `#include <ankerl/unordered_dense.h>` is wrapped in `#ifdef __SS_DENSE_TABLE`, so default builds never even parse the vendored header and have zero dependency on it.
+
+- **API-compatible.** Every use of the underlying container in the runtime (`find`, `begin/end`, `erase(it)`, `operator[]`, `insert`, `reserve`, `size`, `clear`, range-for) is a strict subset of the standard associative API, so the swap is a pair of typedefs plus the vendored header — no changes to `dict.hpp`/`set.hpp` logic. The Boehm `gc_allocator` flows through to both the value-vector and bucket-vector, keeping everything GC-scanned and alive.
+
+## Changes
+
+**Runtime**
+- `shedskin/lib/builtin.hpp` — `__GC_DICT`/`__GC_SET` select `ankerl::unordered_dense::{map,set}` under `__SS_DENSE_TABLE`, else the existing `std::unordered_{map,set}` (all four GC/NOGC branches); vendored `#include` guarded by the macro.
+
+- `shedskin/ext/include/ankerl/unordered_dense.h` — vendored single-header `ankerl::unordered_dense` v4.5.0 (MIT). New third-party dir `shedskin/ext/include/`.
+
+**Compiler / CLI**
+- `shedskin/state/build_config.py` — new `dense_table: bool = False` field.
+
+- `shedskin/config.py` — `dense_table` property.
+
+- `shedskin/__init__.py` — `--dense-table` CLI flag → `gx.dense_table`.
+
+- `shedskin/makefile.py` — adds `shedskin/ext/include` to the include path in both the direct builder and the Makefile generator; emits `-D__SS_DENSE_TABLE` when the flag is set.
+
+- `shedskin/cmake.py` — `add_shedskin_product` gains an `enable_dense_table` keyword (emits `ENABLE_DENSE_TABLE`); `generate_cmakefile` forwards `gx.dense_table` to all three product call sites.
+
+**CMake resources**
+- `shedskin/resources/cmake/fn_add_shedskin_product.cmake`
+
+  - `ENABLE_DENSE_TABLE` added to the function's `options`.
+
+  - Both the executable and extension targets get `$<$<OR:$<BOOL:${SHEDSKIN_ENABLE_DENSE_TABLE}>,$<BOOL:${ENABLE_DENSE_TABLE}>>:__SS_DENSE_TABLE>`, so it responds to both the function keyword and a direct `-DENABLE_DENSE_TABLE=ON` at configure time.
+
+  - Self-derives `SHEDSKIN_EXT_INCLUDE` from `SHEDSKIN_LIB` (its parent + `/ext/include`) so every caller — `examples/`, `tests/`, and `shedskin build`-generated projects — gets the vendored include path without each `CMakeLists.txt` having to define it.
+
+**Benchmark**
+- `tests/benchmarks/dict_set_bench.py` — synthetic benchmark over eight dict/set access patterns (build, lookup, iterate, churn, str-keyed, set build, membership, set algebra).
+
+- `tests/benchmarks/dict-set-benchmark.md` — results and analysis.
+
+- `tests/benchmarks/README.md` — documents the second benchmark and the old-vs-new comparison via `--dense-table`.
+
+## Usage
+
+```bash
+# Makefile backend
+shedskin translate --dense-table prog.py && make && ./prog
+
+# CMake backend
+shedskin build --dense-table prog.py        # generates add_shedskin_product(ENABLE_DENSE_TABLE ...)
+
+# Direct CMake option (test suite / hand-written CMake projects)
+cmake -DENABLE_DENSE_TABLE=ON -S . -B build
+shedskin runtests --run test_type_dict -c ENABLE_DENSE_TABLE=ON
+```
+
+## Benchmark results
+
+`tests/benchmarks/dict_set_bench.py`, N=100000, `-O2 -std=c++20`, Boehm GC, best-of-several runs (seconds). Default STL vs `--dense-table`:
+
+| Section          | What it stresses            | STL (default) | dense (`--dense-table`) | Speedup |
+|------------------|-----------------------------|---------------|-------------------------|---------|
+| DICT_INT_BUILD   | int->int insert + growth    | 0.248         | 0.160                   | 1.6x    |
+| DICT_INT_LOOKUP  | int point lookup, ~half miss| 0.050         | 0.091                   | 0.55x   |
+| DICT_INT_ITER    | iterate all items           | 0.253         | 0.011                   | 23x     |
+| DICT_INT_CHURN   | insert then pop every key   | 0.378         | 0.246                   | 1.5x    |
+| DICT_STR         | str-keyed build + lookup    | 1.035         | 0.825                   | 1.3x    |
+| SET_BUILD        | int set insert + dedup      | 0.292         | 0.149                   | 2.0x    |
+| SET_MEMBER       | int membership, ~half miss  | 0.082         | 0.105                   | 0.78x   |
+| SET_OPS          | intersection + union        | 2.605         | 0.620                   | 4.2x    |
+| **TOTAL**        |                             | **4.97**      | **2.22**                | **2.2x**|
+
+Open-addressing wins big on iteration (~23x, dense contiguous scan vs pointer chase) and set algebra (~4x), and 1.3-2x on construction/churn. It is ~1.3-1.8x *slower* on pure integer point-lookups, because `unordered_dense` applies a wyhash finalizer on top of `ss_hash` (which is `std::hash<int>`, i.e. the identity on libstdc++/libc++, and would cluster badly without mixing). We deliberately keep the mix — the absolute lookup cost is tiny and the robustness matters for sequential-integer-key programs. Net on this mixed workload: ~2.2x.
+
+## Testing
+
+- `make test` (unit suite): 246 passed.
+
+- `mypy` clean on all modified Python modules.
+
+- dict/set correctness programs pass in both executable and extension-module modes, default and `--dense-table`: `test_type_dict`, `test_type_set`, `test_mod_collections`, `test_mod_copy`, `test_mod_os`, plus dict/set-heavy programs (`dijkstra`, `soduko`, `horn`).
+
+- All eight benchmark checksums are bit-identical between the STL and dense backends; the count-valued ones also match CPython.
+
+- All four backend branches exercised: GC/NOGC x STL/dense.
+
+## Backward compatibility
+
+Default behavior is unchanged: no flag means the STL backend, the vendored header is not included, and the `-I shedskin/ext/include` entry (added unconditionally to the include path) is harmless when unused. No generated-code or API changes.
+
+## Notes / caveats
+
+- **Vendored dependency:** `ankerl::unordered_dense` v4.5.0, single MIT-licensed header. The v4.5.0 tag is a genuine standalone amalgamation; `main` (4.8.x) was split into a non-self-contained `stl.h` and is unsuitable for vendoring as-is.
+
+- **Warnings:** under `-Wall -Wextra -Wconversion` the vendored header emits benign `-Wsign-conversion` notes (a `long -> uint64_t` in its hash mixing of the `ss_hash` result). It is third-party code and is left unpatched; if desired it can be silenced by including `ext/include` via `-isystem` instead of `-I`.
+
+- **Impact is workload-dependent:** iteration/construction/set-algebra-heavy code wins substantially; lookup-bound integer-keyed code is flat-to-slightly-slower. This converts the review's analytical "High" rating into measured evidence.
+
+## Not in this PR
+
+- `examples/amaze/amaze.py` (a type-inference convergence fix using a `(-1, -1)` point sentinel) is unrelated to the backend and should land separately.
+
+---
+
+Generated with Claude Code (https://claude.com/claude-code)

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,197 @@
+# Shed Skin Code-Generation Review
+
+**Scope.** How Shed Skin turns (restricted) Python 3 into C++, and the quality and performance of the C++ it emits. The focus is the generator (`shedskin/cpp.py`, `typestr.py`, `virtual.py`, `extmod.py`) and the runtime library the generated code calls into (`shedskin/lib/`), because emitted-code performance is a joint product of the two. Type-inference *correctness* (integer overflow, container specialization, etc.) is covered by a separate review and only cross-referenced here. Throughout, three distinct concerns are kept separate because they have different owners and fixes: the **generation process** (what `cpp.py` decides to emit while lowering the AST), **emitted-code quality** (the textual quality of that C++), and **runtime-library performance** (`shedskin/lib/`, which the emitted code links against and which bounds speed independently of the generator). Section 3 is organized on exactly this axis.
+
+**Method.** Direct reading of the generator and runtime, plus **empirical inspection of real emitted C++**: several representative Python programs were compiled with `shedskin translate` and the resulting `.cpp` read line-by-line and recompiled with `g++ -std=c++17 -Wall -Wextra` to observe warnings. Findings tagged **[verified]** were confirmed against emitted output or a compile; **[code]** were read in the compiler/runtime source with `file:line` citations.
+
+**Version.** 0.9.12, branch `master`.
+
+---
+
+## 1. How code is generated
+
+The pipeline is a whole-program, type-directed, single-pass emitter:
+
+```
+graph.parse_module   -> constraint graph from the Python AST      (graph.py)
+infer.analyze        -> whole-program type inference (CPA + IFA)   (infer.py)
+cpp.generate_code    -> emit C++ per module from the typed AST     (cpp.py)
+typestr.*            -> render inferred type-sets as C++ types     (typestr.py)
+makefile / cmake     -> build emitted C++ against shedskin/lib     (the runtime)
+```
+
+**Two-pass per module** (`cpp.py:4467-4479`). For each module a `ConstVisitor` (`cpp.py:148-170`) first walks the AST to intern string/bytes literals into `const_N` globals, then a `GenerateVisitor` (`cpp.py:176`) emits the `.cpp` (`module_cpp`, `cpp.py:572-721`) and `.hpp` (`module_hpp`, `cpp.py:430-492`). `insert_extras` (`cpp.py:251-263`) post-splices includes and forward declarations.
+
+**Visitor dispatch.** Both visitors subclass a hand-rolled `BaseNodeVisitor` (`ast_utils.py:142-179`) dispatching on `visit_<NodeClass>` with `*args` threading the current `(func, class)` context. There is no separate expression/statement IR: statements manage indentation and `;` via `start`/`output`/`eol` (`cpp.py:357-373`); expressions accrete text onto `self.line` via `append`/`visitm` (`cpp.py:363-391`). Every emission decision keys off the inferred type-set in `self.mergeinh` (`= gx.merged_inh`), with `connector()` (`cpp.py:393-400`) choosing `::` / `.` / `->` and `typestr.unboxable()` deciding native operator vs boxed method call.
+
+**Type rendering** (`typestr.typestrnew`, `typestr.py:287-509`) collapses an inferred set of `(class, contour)` pairs to a *single* C++ type by a lowest-common-parent computation (`lowest_common_parents`, `typestr.py:126-165`). When a program point has a real union it widens to an abstract base pointer (`pyiter<T>*`, `pyseq<T>*`, `pyobj*`) and emits upcasts; numeric unions widen to `float`/`complex` (`typestr.py:365-404`). A single concrete class renders to a zero-overhead static type; scalars in `{int,float,bool,complex}` render to unboxed values (`__ss_int`, `__ss_float`, `complex`).
+
+**Memory model.** Every object is a Boehm-GC heap pointer (`pyobj : public gc`, `builtin.hpp:131`); containers are the STL with GC allocators — `list<T>` is `std::vector` (`list.hpp:5-7`), `str` is `std::basic_string` (`str.hpp:6-11`), `dict`/`set` are `std::unordered_map`/`std::unordered_set` (`builtin.hpp:244-249`). Scalars are stored by value in their concrete C++ type; there is **no runtime boxing of ints/floats and no `PyObject` header** — the single biggest structural advantage over CPython.
+
+---
+
+## 2. What the generator does well
+
+The generator is mature and applies a solid set of loop-shape and container-construction optimizations. These are worth stating because the recommendations below should not regress them.
+
+- **Loop specialization.** `for i in range(...)` becomes a native `FAST_FOR` macro (`ast_utils.py:91-97`, `cpp.py:1399-1427`) rather than a heap iterator. Dedicated fast paths exist for `enumerate`, `zip`, `dict` iteration, file iteration, and iterating a literal list/tuple via C++11 braced-init range-for (`cpp.py:1496-1622`).
+
+- **Comprehension pre-sizing.** A comp over a literal `range(N)` or a sized container emits `__ss_result->resize(N)` and writes by index instead of `append()` (`cpp.py:3883-3941`). **[verified]** — a `[x*x for x in range(100)]` compiled to `resize(100)` + `units[__4] = x*x`.
+
+- **Compile-time default arguments.** `f(x, y=10, z=20)` called as `f(1)` emits `f(1, 10, 20)` — defaults resolved at the call site, zero runtime cost. **[verified]**
+
+- **Constant interning.** Single-char string/byte literals map to shared `__char_cache` / `__byte_cache` globals rather than allocating (`cpp.py:229-249`, `builtin.cpp:92-104`); integer-to-string has a chunked digit cache (`str.cpp:748-786`); `''.join(list)` is a single pre-sized allocation (`str.hpp:153-203`).
+
+- **Expression-level fast paths.** `a+b+c...` string chains fold to one `__add_strs` (`cpp.py:2347-2358`); `list + [elt]` avoids a temporary list (`cpp.py:2493-2505`); `t[0]`/`t[1]` on a 2-tuple become `__getfirst__`/`__getsecond__` (`cpp.py:2997-3011`); `x in range(...)` becomes arithmetic with no iteration (`cpp.py:2537-2555`).
+
+- **Unboxed scalars + native arithmetic.** `+ - *` on ints/floats emit raw C++ operators (`cpp.py:2469-2480`, `math.hpp:169-174`); `list<__ss_int>` stores raw machine ints. This is why numeric/array code approaches hand-written C++.
+
+- **Conservative, usage-driven virtualization.** A method is made `virtual` only when it is actually called on a polymorphic receiver *and* a subclass redefines it (`virtual.py:125-198`). Single-implementation hierarchies stay non-virtual and inlinable.
+
+---
+
+## 3. Missed optimizations and low-quality emission, grouped by locus
+
+These findings have three different owners and fixes, and are grouped accordingly; within each group they are ordered by impact. Each is backed by emitted output or a source citation.
+
+- **3A. Generation process** -- decisions `cpp.py` makes while lowering the AST; the fix lives in the generator.
+
+- **3B. Runtime-library performance** -- `shedskin/lib/`, which the emitted code links against; these bound speed regardless of what `cpp.py` emits, and most are fixable without touching the generator.
+
+- **3C. Emitted-code quality** -- textual quality of the produced C++ (redundancy, readability, warnings); little runtime effect, but relevant to the stated goal of readable output.
+
+### 3A. Generation process
+
+#### 3A.1 No fusion of reducers over generator expressions -- HIGHEST IMPACT [verified] [IMPLEMENTED]
+
+`sum(s.area() for s in shapes)` does **not** compile to an accumulation loop. It compiles to a heap-allocated iterator *class* deriving from `__iter<T>`, with captured variables, an `int __last_yield` state field, and a `goto`-based state machine, which `__sum` then drives by **virtual `__get_next()` dispatch per element**:
+
+```cpp
+class list_comp_0 : public __iter<__ss_float> { ... int __last_yield; ... };
+__ss_float list_comp_0::__get_next() {
+    if(!__last_yield) goto __after_yield_0;
+    __last_yield = 0;
+    FOR_IN(s,shapes,0,2,3)
+        __result = s->area();
+        return __result;
+        __after_yield_0:;
+    END_FOR
+    __stop_iteration = true; ...
+}
+...
+return __sum(new list_comp_0(shapes));   // heap alloc + virtual call per element
+```
+
+There is no code path recognizing `reducer(genexpr)` for `sum`/`any`/`all`/`min`/`max` and lowering it to a direct loop (`cpp.py:2896-2960`, `3681-3945`). Every such idiom pays a heap allocation, a vtable indirection per element, and a `goto` state machine, where the equivalent hand C++ is a register accumulator over an inlined vector loop. This is the single largest structural inefficiency in ordinary Python style, and it is the idiomatic way to write reductions.
+
+**Fix.** Special-case `sum/any/all/min/max/"".join` with a single `GeneratorExp`/comp argument: inline the comp body directly into an accumulator loop at the call site (the machinery already exists — `FAST_FOR`/`FOR_IN` plus the resize/reserve logic).
+
+**Status: implemented for `sum`/`any`/`all`/`min`/`max` over a generator expression** (`cpp.py`, `compute_fused_reducers`/`reducer_func`/`emit_reducer_call`). A `reducer(<genexpr>)` call now lowers to a `static inline` accumulator function (no heap allocation, no virtual `__get_next()`, no `goto` state machine); `sum` fuses only for a numeric accumulator, `min`/`max` replicate the runtime's first-element fold and `ValueError`-on-empty, and any non-matching call (e.g. `min`/`max` with `key=`/`default=`, or the varargs form) falls back to the previous path. Verified against CPython (fused + fallback + empty-sequence cases), full unit suite (246 passed), and `mypy --strict` clean.
+
+`"".join` was investigated and deliberately **not** fused: `str::join` already materializes its argument into a pre-sized buffer in one pass, so coercing the genexpr to a list just materializes twice and nets ~0 (measured 0.97x on a realistic format-and-join workload). See `reducer-benchmark.md`. The bracketed `reducer([listcomp])` form remains a possible follow-up. Benchmarks: `tests/benchmarks/reducer_bench.py` gives ~41x for `sum`/`min`/`max` and ~6.5x for `any`/`all` when the reducer is the hot loop; within noise on the example programs that use the pattern only in cold paths (`sunfish`, `sat`).
+
+#### 3A.2 `%` and `/` always emit the floored-semantics helpers [code, verified]
+
+`x % k` always emits `__mods(x,k)` and `x / k` (true div) `__divs`, unconditionally (`cpp.py:2427-2442`), where `__mods`/`__divs` carry sign-correction branches for Python's floored semantics (`math.hpp:124-134`, `103-115`). When both operands are provably non-negative (e.g. a `range` loop variable mod a positive constant) the native `%`/`/` matches Python exactly and is a single instruction. The authors flagged this themselves: `# XXX C++ knows %, /, so we can overload?` (`cpp.py:2426`). A sign/range analysis on the operands would let the common non-negative case use native operators.
+
+### 3B. Runtime-library performance
+
+#### 3B.1 String concatenation in a loop is O(n^2), for both `+` and `+=` -- HIGH IMPACT [verified]
+
+`str::__add__` allocates a fresh buffer and copies both operands every call (`str.cpp:503-511`), and `str::__iadd__` merely forwards to it (`str.cpp:512-514`). So:
+
+```cpp
+FAST_FOR(i,0,n,1,0,1)
+    s = (s)->__iadd__(const_1);   // new allocation + full copy each iteration
+END_FOR
+```
+
+Building a string of length *n* by repeated concatenation is quadratic; `+=` gives no relief because Python string immutability is enforced by always returning a new object. The runtime *has* an in-place `operator+=(const char*)` (`str.cpp:90-96`) but it is used only internally, never for user `+=`.
+
+**Fix (two options).** (a) Emit a mutable accumulator when inference proves the target is not aliased across the loop (the reassignment `s = s + ...` is detectable) and reuse the buffer in place. (b) Recognize the accumulation pattern and lower to a `''.join(...)`-style pre-sized build. Either turns a common O(n^2) idiom into O(n). The runtime already has a fast `join`; the gap is purely codegen not routing to it.
+
+#### 3B.2 `dict`/`set` use `std::unordered_map`/`std::unordered_set` -- HIGH IMPACT [code]
+
+`dict` wraps `std::unordered_map` and `set` wraps `std::unordered_set` (`dict.hpp:45`, `set.hpp:24`, `builtin.hpp:244-249`) -- chaining hashtables that allocate one node per element and chase pointers on every probe. This is the classic slow choice: poor cache locality and per-insert allocation, materially behind CPython's compact open-addressed dict and far behind a modern flat/open-addressing table (e.g. `absl::flat_hash_map`, `robin_hood`, `ankerl::unordered_dense`). For dict/set-churn-heavy programs this is the dominant runtime ceiling. Scalar keys are otherwise cheap (unboxed, direct `std::hash`, value compare -- `hash.hpp:16-38`, `compare.hpp:5-21`); object keys pay a virtual `__hash__`/`__eq__` per probe.
+
+**Fix.** Swap the `__GC_DICT`/`__GC_SET` aliases to a header-only open-addressing map with a GC-aware allocator. This is a localized change (two typedefs plus API shims) with a potentially large, broad speedup and no generator changes.
+
+#### 3B.3 Bounds/wrap checks on every subscript unless globally disabled [code]
+
+Every `list`/`str`/`tuple` subscript routes through `__wrap` (`builtin.hpp:217-227`): a negative-index normalization branch plus a bounds-check branch (both `__builtin_expect(...,0)`), on by default. `__getfast__` -- the variant emitted when the compiler believes access is safe -- **still calls `__wrap`**, so the checks are only removed with a whole-program `-D__SS_NOBOUNDS`/`-D__SS_NOWRAP`. There is no per-access proof (e.g. a `FAST_FOR` index known in `[0,len)`) that elides the check locally.
+
+**Fix.** When inference/loop-shape proves an index is in range and non-negative (the common `for i in range(len(x))` and comprehension-index cases), emit a genuine unchecked access instead of `__getfast__`-that-still-wraps.
+
+#### 3B.4 Generic iteration uses C++ exceptions for `StopIteration` [code]
+
+The default `__iter<T>::__next__` protocol signals end-of-iteration by throwing (`builtin.hpp:426-431`), which the header itself labels "(slow) exception handling" and works around with `__get_next`/`__stop_iteration` (`builtin.hpp:273`, `433-440`). Concrete containers avoid this via the `for_in_*` traits, but any iteration over an abstract `pyiter<T>*` (including the genexpr classes of 3A.1) can land on the exception path.
+
+### 3C. Emitted-code quality
+
+#### 3C.1 Redundant / warning-generating emission [verified]
+
+Compiling the generated `.cpp` with `-Wall -Wextra` produces a steady stream of warnings that reflect genuinely redundant emitted code:
+
+- **Self-assignment in tuple unpacking.** `for a,b in pairs` emits `__0 = __0;` (`-Wself-assign`) before the element extraction -- a literal no-op (`cpp.py` unpack path around `3377-3412`). **[verified]**
+
+- **Dead local temporaries.** Iterator scratch temps (`__iter<T> *__1`, etc.) are declared for every loop even when the specialized macro never uses them, and comp variables left in the parent scope after hoisting are still declared, e.g. an unused `void *s;` (`local_defs`, `cpp.py:3801-3814`, with no liveness check). Multiple `-Wunused-variable` per function. **[verified]**
+
+- **Unused catch variables.** `except E as e:` emits `catch (E *e)` even when `e` is unused (`cpp.py:1348-1352`), yielding `-Wunused-parameter`. The no-name form `catch (E *)` already exists but is used only when the source omits the name. **[verified]**
+
+- **Redundant static tuple-arity check.** Unpacking a statically-typed `tuple<__ss_int>` (arity known at compile time) still emits a runtime `__SS_UNPACK_CHECK(__0, 2)` every iteration. **[verified]**
+
+None of these are correctness bugs, but they are dead code the C++ optimizer must strip and noise that buries real warnings. A `-Wall`-clean generator is achievable: skip self-assigns, run a use-check before declaring locals, omit unused catch names (or tag `[[maybe_unused]]`), and drop the unpack check when arity is statically known.
+
+#### 3C.2 Literal and constant handling [verified / code]
+
+- **Every integer literal is wrapped `__ss_int(...)`** (`cpp.py:4440-4445`), including array indices, loop bounds, and `resize` counts; negatives become `(-__ss_int(1))`. Purely so a `LL` suffix can attach in 64/128-bit mode. Harmless after optimization but a large source of visual noise.
+
+- **`"__main__"` is allocated twice.** `module_cpp` emits `__name__ = new str("__main__")` through a hardcoded path (`cpp.py:648`) that bypasses the const cache, while the user's `if __name__ == "__main__"` interns the same literal as a separate `const_N` (`cpp.py:237`). Result: two identical `new str("__main__")` allocations in essentially every program. **[verified]** Const interning is also strictly per-module -- identical literals across modules are never shared.
+
+- **Constant small-integer powers** rely on a runtime branch in an `inline` `__power` (`math.hpp:11-14`, `20-30`); with a literal exponent the C++ compiler folds it, so this is adequate, not a real miss.
+
+#### 3C.3 Emitted-C++ quality: no `const`, references, or move semantics [code]
+
+The generator emits essentially no `const` (grepping emitted strings yields none), never uses references except for one comprehension capture-by-ref (`cpp.py:3733`), and uses no `std::move`/rvalue refs (consistent with the GC-pointer model but it means inline value tuples are default-copied). Control flow is macro-based (`FAST_FOR`, `FOR_IN`, `WITH`), literals are `__ss_int(...)`-wrapped, and everything is heavily parenthesized (`(((a+b)))`), so output is functional but hard to read. `NULL` is used rather than `nullptr`; no `constexpr`. None of this affects performance after `-O2`, but it lowers the debuggability of generated code -- a stated Shed Skin use case is reading the C++.
+
+---
+
+## 4. Build configuration [code]
+
+Generated builds use `-O2 -march=native` (Makefile, `makefile.py:672-729`) or `-O2` (CMake, `fn_add_shedskin_product.cmake:391`). Notably absent:
+
+- **No `-flto`.** Because each module is its own translation unit, cross-module inlining (e.g. small methods, `__init__`) does not happen. Whole-program transpilers benefit strongly from LTO; offering it would be a low-effort, broad win.
+
+- **No `-O3` option.** The runtime is template/`inline`-heavy; `-O3`'s extra inlining and vectorization can matter for numeric kernels. Worth exposing as a flag (measure per benchmark; `-O3` is not universally faster).
+
+- **No PGO path.** For the target use case (a few hundred lines run at max speed), a profile-guided second build is a natural, high-value option to document/automate.
+
+The runtime headers themselves also emit warnings under `-Wall -Wextra` (deprecated `sprintf` at `math.hpp:291`, unused vars at `math.hpp:230`/`393`) and carry a latent quality bug: `set`'s variadic constructor sets `__class__ = cl_dict` instead of `cl_set` (`set.hpp:199`). **[verified / code]**
+
+---
+
+## 5. Prioritized recommendations
+
+| # | Change | Impact | Effort | Where |
+|---|--------|--------|--------|-------|
+| 1 | Fuse `sum/any/all/min/max/join` over a genexpr/comp into a direct accumulator loop | High (removes heap alloc + per-element virtual dispatch on an idiomatic pattern) | Med | `cpp.py:2896-2960`, `3681-3945` |
+| 2 | Replace `std::unordered_map/set` with an open-addressing table | High (broad dict/set speedup) | Low-Med | `builtin.hpp:244-249` + API shims |
+| 3 | Lower string `+`/`+=` accumulation to in-place/join when target is non-aliased | High (O(n^2) -> O(n)) | Med | `cpp.py` assign path + `str.cpp:503-514` |
+| 4 | Elide bounds/wrap checks per-access when index provably in range | Med (hot subscripts) | Med | `builtin.hpp:217-227`, `__getfast__` emission |
+| 5 | Native `%`/`/` when operands provably non-negative | Med | Med | `cpp.py:2427-2442` |
+| 6 | Make the generator `-Wall`-clean: drop `__0=__0`, dead locals, unused catch names, static-arity unpack checks | Low perf / high hygiene | Low | `cpp.py:1348-1352`, `3377-3412`, `3801-3814` |
+| 7 | Dedup `"__main__"` and share consts cross-module | Low | Low | `cpp.py:237`, `648` |
+| 8 | Offer `-flto`, `-O3`, and a PGO build path | Med (multi-module programs) | Low | `makefile.py`, cmake resources |
+| 9 | Fix runtime warnings and the `set` `__class__ = cl_dict` bug | Correctness/hygiene | Low | `set.hpp:199`, `math.hpp:230/291/393` |
+
+**Framing.** Items 1-3 are the substantive performance work; each targets a *structural* inefficiency (heap-iterator reductions, chaining hashtables, quadratic string build) rather than a micro-optimization, and each is idiomatic Python that a user would not expect to be slow. Items 6-7 are cheap credibility/readability wins given a stated goal of readable generated C++. The generator's numeric/array code path is already close to hand-written C++ and should be left alone.
+
+---
+
+## 6. Caveats and alternative framing
+
+- Several "inefficiencies" are *correctness* requirements, not oversights: `__mods`/`__divs` branches implement Python's floored semantics; string immutability forbids naive in-place `+=` without an aliasing proof. The recommendations above are guarded on exactly those proofs; where inference cannot establish them, the current conservative emission is correct and must stay.
+
+- The dict/set swap (item 2) is the highest-leverage change *if* real workloads are dict/set-bound. That is an empirical question -- the `examples/` benchmark suite should be measured before and after, since some programs are entirely list/int-bound and would see no change. All impact ratings here are analytical, not yet benchmarked; a measurement pass over `examples/` under `asv` would convert them to evidence.
+
+- This review deliberately excludes type-inference correctness (integer overflow, silent wraparound, container-type divergence), which is the subject of the companion correctness review; those are the more dangerous class of issue (silent wrong output) but orthogonal to the code-generation quality assessed here.

--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -52,7 +52,7 @@ from typing import (
 )
 from collections.abc import Iterator
 
-from . import ast_utils, error, extmod, infer, python, typestr, virtual
+from . import ast_utils, error, extmod, infer, python, strbuild, typestr, virtual
 
 if TYPE_CHECKING:
     from . import config
@@ -200,6 +200,10 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
         self.fusedreducer_calls: dict[ast.Call, ast.ListComp] = {}
         self.reducer_kind: Optional[str] = None
         self.reducer_acct = ""
+        # --- string-builder loops (see strbuild)
+        self.sb_loops: dict["python.Function", strbuild.Accumulators] = {}
+        self.sb_active: dict[ast.AugAssign, str] = {}
+        self.sb_count = 0
 
     def cpp_name(self, obj: Any) -> str:
         """Generate a C++ name for an object"""
@@ -855,6 +859,14 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
         self, node: ast.While, func: Optional["python.Function"] = None
     ) -> None:
         """Visit a while node"""
+        opened = self.sb_begin(node, func)
+        self.impl_visit_while(node, func)
+        self.sb_end(opened, func)
+
+    def impl_visit_while(
+        self, node: ast.While, func: Optional["python.Function"] = None
+    ) -> None:
+        """Generate a while loop"""
         self.print()
         if node.orelse:
             self.output("%s = 0;" % self.mv.tempcount[node, "orelse"])
@@ -1481,10 +1493,61 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
         ]
         return not [t for t in self.mergeinh[node] if t[0] not in classes]
 
+    def sb_begin(
+        self, node: ast.stmt, func: Optional["python.Function"]
+    ) -> list[tuple[str, strbuild.Accumulator]]:
+        """Open a string-builder loop, if this loop qualifies (see strbuild)
+
+        Emits a buffer per accumulator, seeded with its current value, and
+        routes the loop's '+=' statements into it. Each buffer is a fresh str
+        that nothing else can reach until sb_end publishes it, so appending
+        into it in place is not observable.
+        """
+        if func is None:
+            return []
+        if func not in self.sb_loops:
+            self.sb_loops[func] = strbuild.loop_accumulators(
+                func, self.gx, self.mergeinh
+            )
+
+        opened = []
+        for acc in self.sb_loops[func].get(node, []):
+            name = "__ss_sb%d" % self.sb_count
+            self.sb_count += 1
+            var = self.cpp_name(acc.name)
+            # seeded by copy, so any pre-loop alias of the accumulator keeps
+            # pointing at the original, unmodified string
+            self.output(
+                "str *%s = %s?(new str(%s->unit)):(new str());" % (name, var, var)
+            )
+            for aug in acc.augassigns:
+                self.sb_active[aug] = name
+            opened.append((name, acc))
+        return opened
+
+    def sb_end(
+        self,
+        opened: list[tuple[str, strbuild.Accumulator]],
+        func: Optional["python.Function"],
+    ) -> None:
+        """Publish the string-builder results and stop routing their '+='"""
+        for name, acc in opened:
+            for aug in acc.augassigns:
+                del self.sb_active[aug]
+            self.output("%s = %s;" % (self.cpp_name(acc.name), name))
+
     def visit_For(
         self, node: ast.For, func: Optional["python.Function"] = None
     ) -> None:
         """Visit a for loop node"""
+        opened = self.sb_begin(node, func)
+        self.impl_visit_for(node, func)
+        self.sb_end(opened, func)
+
+    def impl_visit_for(
+        self, node: ast.For, func: Optional["python.Function"] = None
+    ) -> None:
+        """Generate a for loop"""
         if isinstance(node.target, ast.Name):
             assname = node.target.id
         elif ast_utils.is_assign_attribute(node.target):
@@ -2224,6 +2287,14 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
         self, node: ast.AugAssign, func: Optional["python.Function"] = None
     ) -> None:
         """Visit an augmented assignment"""
+        # inside a string-builder loop, append into the buffer instead of
+        # reallocating and copying the whole accumulator (see strbuild)
+        if node in self.sb_active:
+            self.start(self.sb_active[node] + "->unit.append((")
+            self.visitm(node.value, ")->unit)", func)
+            self.eol()
+            return
+
         if isinstance(node.target, ast.Subscript):
             self.start()
             if {

--- a/shedskin/strbuild.py
+++ b/shedskin/strbuild.py
@@ -1,0 +1,153 @@
+# SHED SKIN Python-to-C++ Compiler
+# Copyright 2005-2026 Mark Dufour and contributors; GNU GPL version 3 (See LICENSE)
+"""shedskin.strbuild: recognize loops that only append to a local string
+
+A loop of the shape
+
+    out = ''
+    for x in xs:
+        out += f(x)
+
+is quadratic in shed skin. Strings are immutable, so each '+=' allocates a
+fresh str and copies both operands; over n iterations that copies O(n**2)
+bytes. CPython does not have this problem because it resizes the left operand
+in place whenever it holds the only reference to it. Shed skin has no reference
+counts to consult at run time, so the equivalent question is answered at
+compile time instead: if the accumulator is a local that the loop touches
+*only* as the target of '+=', then nothing can observe it while the loop runs,
+and codegen is free to append into a single buffer and publish the result once,
+after the loop.
+
+`loop_accumulators` reports the loops in a function for which that holds. The
+codegen side lives in `cpp.GenerateVisitor.sb_begin`/`sb_end`.
+
+The conditions are deliberately conservative; each one exists because dropping
+it makes an observable difference:
+
+- Every occurrence of the name in the loop, header included, must be an
+  augmented-assignment target. A read would see the accumulator's pre-loop
+  value, which is stale. This also rules out `out += out`, and rules out the
+  `while` test re-reading it on each iteration.
+- The loop may not sit inside a `try` in the same function. If an exception
+  escapes the loop, python leaves the accumulator holding everything appended
+  so far, whereas a builder would not have published anything yet.
+- The loop may not have an `else` clause, which would run before the value is
+  published.
+- The function may not be a generator, whose locals survive across yields.
+
+Loops nested inside a qualifying loop are left alone: the outermost one already
+covers them, and transforming both would publish (and copy) once per outer
+iteration.
+"""
+
+import ast
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+from . import python
+
+if TYPE_CHECKING:
+    from . import config
+
+
+class Accumulator(NamedTuple):
+    """A local string a loop only ever appends to"""
+
+    name: str
+    """name of the accumulated variable"""
+
+    augassigns: list[ast.AugAssign]
+    """the '+=' statements to rewrite into appends"""
+
+
+Types = Any
+Accumulators = dict[ast.stmt, list[Accumulator]]
+
+
+def loop_accumulators(
+    func: "python.Function", gx: "config.GlobalInfo", mergeinh: dict[Any, Types]
+) -> Accumulators:
+    """Map each qualifying loop in func to the string it accumulates"""
+    result: Accumulators = {}
+    fnode = func.node
+    if fnode is None or func.isGenerator or func.listcomp:
+        return result
+    if not isinstance(fnode, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return result
+    _scan(list(fnode.body), func, gx, mergeinh, _loops_under_try(fnode), result)
+    return result
+
+
+def _scan(
+    stmts: list[ast.stmt],
+    func: "python.Function",
+    gx: "config.GlobalInfo",
+    mergeinh: dict[Any, Types],
+    disqualified: set[ast.stmt],
+    result: Accumulators,
+) -> None:
+    """Claim the outermost qualifying loop along each path"""
+    for stmt in stmts:
+        if isinstance(stmt, (ast.For, ast.While)) and stmt not in disqualified:
+            accs = _accumulators(stmt, func, gx, mergeinh)
+            if accs:
+                result[stmt] = accs
+                continue  # nested loops are already covered by this one
+        for child in ast.iter_child_nodes(stmt):
+            if isinstance(child, ast.stmt):
+                _scan([child], func, gx, mergeinh, disqualified, result)
+            elif isinstance(child, ast.ExceptHandler):
+                _scan(list(child.body), func, gx, mergeinh, disqualified, result)
+
+
+def _loops_under_try(fnode: ast.AST) -> set[ast.stmt]:
+    """Loops sitting inside a 'try' in this function"""
+    inside: set[ast.stmt] = set()
+    for node in ast.walk(fnode):
+        if isinstance(node, ast.Try):
+            for child in ast.walk(node):
+                if isinstance(child, (ast.For, ast.While)):
+                    inside.add(child)
+    return inside
+
+
+def _accumulators(
+    loop: ast.stmt,
+    func: "python.Function",
+    gx: "config.GlobalInfo",
+    mergeinh: dict[Any, Types],
+) -> list[Accumulator]:
+    """The strings this loop only ever appends to"""
+    found: list[Accumulator] = []
+    if getattr(loop, "orelse", None):
+        return found
+
+    candidates: dict[str, list[ast.AugAssign]] = {}
+    for node in ast.walk(loop):
+        if (
+            isinstance(node, ast.AugAssign)
+            and isinstance(node.op, ast.Add)
+            and isinstance(node.target, ast.Name)
+            and _is_str(gx, mergeinh, node.value)
+        ):
+            candidates.setdefault(node.target.id, []).append(node)
+
+    for name, augassigns in candidates.items():
+        if name in func.globals or name not in func.vars:
+            continue
+        # the target is in Store context and so carries no type of its own;
+        # the accumulator's type lives on the variable
+        if not _is_str(gx, mergeinh, func.vars[name]):
+            continue
+        targets = {id(aug.target) for aug in augassigns}
+        if all(
+            id(node) in targets
+            for node in ast.walk(loop)
+            if isinstance(node, ast.Name) and node.id == name
+        ):
+            found.append(Accumulator(name, augassigns))
+    return found
+
+
+def _is_str(gx: "config.GlobalInfo", mergeinh: dict[Any, Types], thing: Any) -> bool:
+    """Whether an ast node's or variable's inferred type is exactly str"""
+    return mergeinh.get(thing) == {(python.def_class(gx, "str_"), 0)}

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -1,13 +1,8 @@
 # Shed Skin micro-benchmarks
 
-Synthetic benchmarks for specific code-generation and runtime optimizations from
-`REVIEW.md`. Each exists because no program in `examples/` or `tests/` drives the
-relevant pattern in a hot loop, so the optimization's effect is invisible on the
-regular suite.
+Synthetic benchmarks for specific code-generation and runtime optimizations from `REVIEW.md`. Each exists because no program in `examples/` or `tests/` drives the relevant pattern in a hot loop, so the optimization's effect is invisible on the regular suite.
 
-This directory is intentionally **not** named `test_*`, so it is not picked up by
-the auto-discovered correctness suite (`make test`); these are standalone
-benchmarks you build and run manually.
+This directory is intentionally **not** named `test_*`, so it is not picked up by the auto-discovered correctness suite (`make test`); these are standalone benchmarks you build and run manually.
 
 | Benchmark            | REVIEW.md item | Measures                                   |
 |----------------------|----------------|--------------------------------------------|
@@ -18,9 +13,7 @@ benchmarks you build and run manually.
 
 # Reducer/genexpr fusion benchmark
 
-`reducer_bench.py` is a synthetic benchmark for the code-generation optimization
-that fuses `sum`/`any`/`all` over a **generator expression** into a direct
-accumulator loop (REVIEW.md finding 3A.1).
+`reducer_bench.py` is a synthetic benchmark for the code-generation optimization that fuses `sum`/`any`/`all` over a **generator expression** into a direct accumulator loop (REVIEW.md finding 3A.1).
 
 ## Build and run (current compiler)
 
@@ -35,13 +28,11 @@ make
 # TIME 0.028
 ```
 
-Each section prints its own wall-clock time and a `CHECKSUM`; the checksums must
-be identical between the fused and unfused builds.
+Each section prints its own wall-clock time and a `CHECKSUM`; the checksums must be identical between the fused and unfused builds.
 
 ## Compare fused vs unfused
 
-The workload is fixed; the two data points come from compiling it with and
-without the fusion. From a clean checkout with the fusion applied:
+The workload is fixed; the two data points come from compiling it with and without the fusion. From a clean checkout with the fusion applied:
 
 ```bash
 # fused (current working tree)
@@ -53,20 +44,13 @@ shedskin translate reducer_bench.py && make && ./reducer_bench   # note TIME
 git stash pop
 ```
 
-The `CHECKSUM` line must be identical for both builds (correctness); the `TIME`
-line is the measurement.
+The `CHECKSUM` line must be identical for both builds (correctness); the `TIME` line is the measurement.
 
 ---
 
 # dict/set backend benchmark
 
-`dict_set_bench.py` measures the dict/set runtime for the alternative
-open-addressing backend added in item 2 of REVIEW.md. The default `__GC_DICT` /
-`__GC_SET` backend in `shedskin/lib/builtin.hpp` remains the chaining STL
-hashtables; the `--dense-table` option opts into an open-addressing table
-(`ankerl::unordered_dense`, vendored under `shedskin/ext/include/ankerl/`). The
-benchmark drives eight dict/set access patterns -- build, lookup, iterate, churn,
-membership, and set algebra -- over a runtime-populated working set.
+`dict_set_bench.py` measures the dict/set runtime for the alternative open-addressing backend added in item 2 of REVIEW.md. The default `__GC_DICT` / `__GC_SET` backend in `shedskin/lib/builtin.hpp` remains the chaining STL hashtables; the `--dense-table` option opts into an open-addressing table (`ankerl::unordered_dense`, vendored under `shedskin/ext/include/ankerl/`). The benchmark drives eight dict/set access patterns -- build, lookup, iterate, churn, membership, and set algebra -- over a runtime-populated working set.
 
 ## Build and run (current compiler)
 
@@ -79,12 +63,7 @@ make
 
 ## Compare old (STL) vs new (open-addressing) table
 
-Unlike the reducer benchmark, the two data points here come from a build-time
-switch, not a source edit. The default chaining `std::unordered_map`/`set`
-backend is used unless the `--dense-table` command-line option is given, which
-opts into the open-addressing table (mapping to `-D__SS_DENSE_TABLE` for the
-Makefile build and to the `ENABLE_DENSE_TABLE` CMake option for `shedskin
-build`/`run`):
+Unlike the reducer benchmark, the two data points here come from a build-time switch, not a source edit. The default chaining `std::unordered_map`/`set` backend is used unless the `--dense-table` command-line option is given, which opts into the open-addressing table (mapping to `-D__SS_DENSE_TABLE` for the Makefile build and to the `ENABLE_DENSE_TABLE` CMake option for `shedskin build`/`run`):
 
 ```bash
 # default STL table
@@ -96,6 +75,4 @@ shedskin translate --dense-table dict_set_bench.py && make && ./dict_set_bench
 # (equivalently, without re-translating: make CPPFLAGS=-D__SS_DENSE_TABLE)
 ```
 
-All eight `CHECKSUM` lines must be identical between the two builds
-(correctness); the `TIME` lines are the measurement. Results and analysis are
-recorded in `dict-set-benchmark.md`.
+All eight `CHECKSUM` lines must be identical between the two builds (correctness); the `TIME` lines are the measurement. Results and analysis are recorded in `dict-set-benchmark.md`.

--- a/tests/benchmarks/dict-set-benchmark.md
+++ b/tests/benchmarks/dict-set-benchmark.md
@@ -1,19 +1,8 @@
 # dict/set backend benchmark (REVIEW.md item 2)
 
-Measures Shed Skin's dict/set runtime for the optional open-addressing backend
-added in item 2 of REVIEW.md. The default `__GC_DICT` / `__GC_SET` backend in
-`shedskin/lib/builtin.hpp` remains the chaining STL hashtables
-(`std::unordered_map` / `std::unordered_set`); the `--dense-table` option opts
-into an open-addressing table (`ankerl::unordered_dense` 4.5.0, vendored at
-`shedskin/ext/include/ankerl/`).
+Measures Shed Skin's dict/set runtime for the optional open-addressing backend added in item 2 of REVIEW.md. The default `__GC_DICT` / `__GC_SET` backend in `shedskin/lib/builtin.hpp` remains the chaining STL hashtables (`std::unordered_map` / `std::unordered_set`); the `--dense-table` option opts into an open-addressing table (`ankerl::unordered_dense` 4.5.0, vendored at `shedskin/ext/include/ankerl/`).
 
-Workload: `dict_set_bench.py` in this directory. Both builds run identical code
-over a runtime-populated working set of `N = 100000` keys; the multipliers keep
-key generation inside a signed 32-bit int so the two builds -- and CPython --
-see the exact same keys. The count-valued CHECKSUM lines (`BUILD`, `STR`,
-`SET_*`) therefore match CPython exactly; the additive-sum lines wrap identically
-in both Shed Skin builds (32-bit `__ss_int`), so all eight CHECKSUMs are
-bit-identical between the old and new table -- correctness holds.
+Workload: `dict_set_bench.py` in this directory. Both builds run identical code over a runtime-populated working set of `N = 100000` keys; the multipliers keep key generation inside a signed 32-bit int so the two builds -- and CPython -- see the exact same keys. The count-valued CHECKSUM lines (`BUILD`, `STR`, `SET_*`) therefore match CPython exactly; the additive-sum lines wrap identically in both Shed Skin builds (32-bit `__ss_int`), so all eight CHECKSUMs are bit-identical between the old and new table -- correctness holds.
 
 ## How it was measured
 
@@ -45,31 +34,12 @@ Apple M-series, `-O2 -std=c++20`, Boehm GC, best of several runs (seconds).
 
 ## Reading the result
 
-The open-addressing table is a large, structural win where the review predicted
-it -- anything that traverses or bulk-processes the container:
+The open-addressing table is a large, structural win where the review predicted it -- anything that traverses or bulk-processes the container:
 
-- **Iteration is ~23x faster.** `unordered_dense` stores entries densely in a
-  contiguous vector, so a full scan is a linear cache-friendly walk that the
-  compiler can vectorize; the chaining table pointer-chases one heap node per
-  element. This is the single biggest structural difference and it dominates any
-  iteration-heavy program.
-- **Set algebra is ~4x, bulk build/dedup ~1.6-2x.** Same cause: contiguous
-  storage and one amortized allocation growth instead of per-element node
-  allocation.
+- **Iteration is ~23x faster.** `unordered_dense` stores entries densely in a contiguous vector, so a full scan is a linear cache-friendly walk that the compiler can vectorize; the chaining table pointer-chases one heap node per element. This is the single biggest structural difference and it dominates any iteration-heavy program.
 
-The cost shows up in **pure point lookups on integer keys**, which are ~1.3-1.8x
-*slower*. `unordered_dense` applies an extra hash-mixing step (wyhash finalizer)
-on top of `ss_hash`, because it must not assume the incoming hash is well
-distributed -- `ss_hash<int>` is `std::hash<int>`, i.e. the identity on
-libstdc++/libc++, which would cluster badly in an open-addressing table without
-mixing. For a lookup where the base hash is nearly free, that mix is pure
-overhead. We deliberately keep the mix (do **not** mark `ss_hash` avalanching):
-it is what makes the table robust for the sequential-integer-key case that real
-programs hit, and the absolute cost is tiny (~0.09s for 24M lookups).
+- **Set algebra is ~4x, bulk build/dedup ~1.6-2x.** Same cause: contiguous storage and one amortized allocation growth instead of per-element node allocation.
 
-Net on this deliberately mixed workload: **~2.2x**. The real-world figure is
-workload-dependent -- iteration/construction/set-op-heavy code wins big,
-lookup-bound integer-keyed code is roughly flat-to-slightly-slower. This matches
-the review's own caveat that the impact rating was analytical and needed
-measurement; the swap is a clear win in aggregate and an unambiguous one for the
-iteration and set-algebra patterns, with the honest caveat noted above.
+The cost shows up in **pure point lookups on integer keys**, which are ~1.3-1.8x *slower*. `unordered_dense` applies an extra hash-mixing step (wyhash finalizer) on top of `ss_hash`, because it must not assume the incoming hash is well distributed -- `ss_hash<int>` is `std::hash<int>`, i.e. the identity on libstdc++/libc++, which would cluster badly in an open-addressing table without mixing. For a lookup where the base hash is nearly free, that mix is pure overhead. We deliberately keep the mix (do **not** mark `ss_hash` avalanching): it is what makes the table robust for the sequential-integer-key case that real programs hit, and the absolute cost is tiny (~0.09s for 24M lookups).
+
+Net on this deliberately mixed workload: **~2.2x**. The real-world figure is workload-dependent -- iteration/construction/set-op-heavy code wins big, lookup-bound integer-keyed code is roughly flat-to-slightly-slower. This matches the review's own caveat that the impact rating was analytical and needed measurement; the swap is a clear win in aggregate and an unambiguous one for the iteration and set-algebra patterns, with the honest caveat noted above.

--- a/tests/test_opt_string_builder/CMakeLists.txt
+++ b/tests/test_opt_string_builder/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_shedskin_product()

--- a/tests/test_opt_string_builder/test_opt_string_builder.py
+++ b/tests/test_opt_string_builder/test_opt_string_builder.py
@@ -1,0 +1,235 @@
+"""Loops that only append to a local str are rewritten to build into a single
+buffer (see shedskin/strbuild.py). These check that the rewrite preserves
+semantics, and -- just as importantly -- that it stays off in the cases where
+it would not."""
+
+
+def test_basic():
+    out = ""
+    for i in range(5):
+        out += str(i)
+    assert out == "01234"
+
+
+def test_seeded():
+    out = "seed:"
+    for i in range(3):
+        out += "x"
+    assert out == "seed:xxx"
+
+
+def test_alias_not_mutated():
+    # the builder is seeded by copy, so a pre-loop alias keeps pointing at the
+    # original string
+    a = "start"
+    b = a
+    for i in range(3):
+        a += "x"
+    assert a == "startxxx"
+    assert b == "start"
+
+
+def test_zero_iterations():
+    out = "init"
+    for i in range(0):
+        out += "never"
+    assert out == "init"
+
+
+def test_break_and_continue():
+    out = ""
+    for i in range(10):
+        if i % 2 == 0:
+            continue
+        if i > 6:
+            break
+        out += str(i)
+    assert out == "135"
+
+
+def test_nested_loops():
+    out = ""
+    for i in range(3):
+        for j in range(2):
+            out += str(i) + str(j)
+    assert out == "000110112021"
+
+
+def test_two_accumulators():
+    a = ""
+    b = ""
+    for i in range(3):
+        a += "a"
+        b += "b"
+    assert a == "aaa"
+    assert b == "bbb"
+
+
+def test_while_loop():
+    out = ""
+    i = 0
+    while i < 5:
+        out += str(i)
+        i += 1
+    assert out == "01234"
+
+
+def append_p(out):
+    for i in range(3):
+        out += "p"
+    return out
+
+
+def test_formal_parameter():
+    assert append_p("start:") == "start:ppp"
+
+
+def test_read_inside_loop():
+    # reading the accumulator mid-loop must keep the unoptimized behaviour
+    out = ""
+    for i in range(4):
+        out += "y"
+        if len(out) == 2:
+            out += "!"
+    assert out == "yy!yy"
+
+
+def test_self_append():
+    out = "ab"
+    for i in range(3):
+        out += out
+    assert out == "abababababababab"
+
+
+def test_while_test_reads_accumulator():
+    out = "a"
+    while len(out) < 6:
+        out += "b"
+    assert out == "abbbbb"
+
+
+def test_reassigned_inside_loop():
+    out = ""
+    for i in range(4):
+        out += "a"
+        if i == 1:
+            out = "R"
+    assert out == "Raa"
+
+
+def test_read_in_iter():
+    out = "xy"
+    total = ""
+    for c in out:
+        total += c
+        out += "!"
+    assert out == "xy!!"
+    assert total == "xy"
+
+
+def test_exception_escapes_loop():
+    # python leaves the accumulator holding everything appended before the
+    # exception, so a loop inside a try keeps the unoptimized behaviour
+    out = ""
+    try:
+        for i in range(10):
+            out += str(i)
+            if i == 4:
+                raise ValueError("stop")
+    except ValueError:
+        pass
+    assert out == "01234"
+
+
+def test_for_else():
+    out = ""
+    for i in range(3):
+        out += "z"
+    else:
+        out += "E"
+    assert out == "zzzE"
+
+
+def gen(n):
+    # a generator's locals survive across yields, so the rewrite stays off
+    out = ""
+    for i in range(n):
+        out += str(i)
+        yield out
+
+
+def test_generator():
+    assert list(gen(3)) == ["0", "01", "012"]
+
+
+class Acc:
+    def __init__(self):
+        self.s = ""
+
+    def run(self, n):
+        # 'out' is a local and is rewritten; 'self.s' is an attribute and is not
+        out = ""
+        for i in range(n):
+            out += str(i)
+            self.s += str(i)
+        return out
+
+
+def test_attribute_accumulator():
+    a = Acc()
+    assert a.run(3) == "012"
+    assert a.s == "012"
+
+
+def test_computed_values():
+    out = ""
+    for w in ["ab", "cd"]:
+        out += w.upper() + "-"
+    assert out == "AB-CD-"
+
+
+def test_conditional_append():
+    out = ""
+    for i in range(6):
+        if i % 2:
+            out += str(i)
+    assert out == "135"
+
+
+def test_deeply_nested_append():
+    out = ""
+    for i in range(4):
+        if i > 0:
+            j = 0
+            while j < i:
+                out += "*"
+                j += 1
+    assert out == "******"
+
+
+def test_all():
+    test_basic()
+    test_seeded()
+    test_alias_not_mutated()
+    test_zero_iterations()
+    test_break_and_continue()
+    test_nested_loops()
+    test_two_accumulators()
+    test_while_loop()
+    test_formal_parameter()
+    test_read_inside_loop()
+    test_self_append()
+    test_while_test_reads_accumulator()
+    test_reassigned_inside_loop()
+    test_read_in_iter()
+    test_exception_escapes_loop()
+    test_for_else()
+    test_generator()
+    test_attribute_accumulator()
+    test_computed_values()
+    test_conditional_append()
+    test_deeply_nested_append()
+
+
+if __name__ == "__main__":
+    test_all()

--- a/tests/unit/test_strbuild.py
+++ b/tests/unit/test_strbuild.py
@@ -1,0 +1,192 @@
+# SHED SKIN Python-to-C++ Compiler
+# Copyright 2005-2026 Mark Dufour and contributors; GNU GPL version 3 (See LICENSE)
+"""Unit tests for shedskin.strbuild module."""
+
+import argparse
+import ast
+
+import pytest
+
+from shedskin import graph, python, strbuild
+from shedskin.config import GlobalInfo
+
+
+@pytest.fixture
+def gx():
+    """GlobalInfo with the builtin module loaded, so def_class('str_') works."""
+    options = argparse.Namespace()
+    info = GlobalInfo(options)
+    graph.parse_module("builtin", info)
+    return info
+
+
+def analyze(gx, source, str_vars=("out", "a", "b", "total"), is_generator=False):
+    """Run loop_accumulators over the single function in `source`.
+
+    The real pipeline supplies types via inference; here the variables named in
+    `str_vars` are simply declared to be strings, which is what the analysis
+    actually consults.
+    """
+    tree = ast.parse(source)
+    fnode = tree.body[0]
+    assert isinstance(fnode, ast.FunctionDef)
+
+    func = python.Function(gx, node=fnode, mv=gx.modules["builtin"].mv)
+    func.isGenerator = is_generator
+    # graph.ModuleVisitor.visit_Global does this during the real pipeline
+    for node in ast.walk(fnode):
+        if isinstance(node, ast.Global):
+            func.globals += node.names
+
+    str_class = python.def_class(gx, "str_")
+    mergeinh = {}
+    for name in str_vars:
+        var = python.Variable(name, func)
+        func.vars[name] = var
+        mergeinh[var] = {(str_class, 0)}
+    # every '+=' right-hand side in these fixtures is a string
+    for node in ast.walk(fnode):
+        if isinstance(node, ast.AugAssign):
+            mergeinh[node.value] = {(str_class, 0)}
+
+    return strbuild.loop_accumulators(func, gx, mergeinh)
+
+
+def accumulated_names(result):
+    """Flatten the analysis result to the set of accumulated variable names."""
+    return {acc.name for accs in result.values() for acc in accs}
+
+
+class TestQualifying:
+    """Loops the rewrite applies to"""
+
+    def test_simple_for(self, gx):
+        result = analyze(gx, "def f():\n out = ''\n for i in r:\n  out += 'x'\n")
+        assert accumulated_names(result) == {"out"}
+
+    def test_simple_while(self, gx):
+        result = analyze(gx, "def f():\n out = ''\n while c:\n  out += 'x'\n")
+        assert accumulated_names(result) == {"out"}
+
+    def test_two_accumulators(self, gx):
+        result = analyze(
+            gx, "def f():\n for i in r:\n  a += 'x'\n  b += 'y'\n"
+        )
+        assert accumulated_names(result) == {"a", "b"}
+
+    def test_conditional_append(self, gx):
+        result = analyze(
+            gx, "def f():\n for i in r:\n  if i:\n   out += 'x'\n"
+        )
+        assert accumulated_names(result) == {"out"}
+
+    def test_break_and_continue_allowed(self, gx):
+        result = analyze(
+            gx,
+            "def f():\n for i in r:\n  if i:\n   continue\n  if j:\n   break\n  out += 'x'\n",
+        )
+        assert accumulated_names(result) == {"out"}
+
+    def test_reads_after_loop_allowed(self, gx):
+        result = analyze(
+            gx, "def f():\n for i in r:\n  out += 'x'\n return out\n"
+        )
+        assert accumulated_names(result) == {"out"}
+
+    def test_try_inside_loop_allowed(self, gx):
+        # only the loop being *inside* a try is a problem
+        result = analyze(
+            gx,
+            "def f():\n for i in r:\n  try:\n   g()\n  except E:\n   pass\n  out += 'x'\n",
+        )
+        assert accumulated_names(result) == {"out"}
+
+
+class TestDisqualifying:
+    """Loops the rewrite must stay away from"""
+
+    def test_read_inside_loop(self, gx):
+        result = analyze(
+            gx, "def f():\n for i in r:\n  out += 'x'\n  print(out)\n"
+        )
+        assert result == {}
+
+    def test_self_append(self, gx):
+        result = analyze(gx, "def f():\n for i in r:\n  out += out\n")
+        assert result == {}
+
+    def test_reassigned_inside_loop(self, gx):
+        result = analyze(
+            gx, "def f():\n for i in r:\n  out += 'x'\n  out = 'r'\n"
+        )
+        assert result == {}
+
+    def test_while_test_reads_accumulator(self, gx):
+        result = analyze(gx, "def f():\n while len(out) < 3:\n  out += 'x'\n")
+        assert result == {}
+
+    def test_read_in_for_iter(self, gx):
+        result = analyze(gx, "def f():\n for c in out:\n  out += 'x'\n")
+        assert result == {}
+
+    def test_loop_inside_try(self, gx):
+        result = analyze(
+            gx,
+            "def f():\n try:\n  for i in r:\n   out += 'x'\n except E:\n  pass\n",
+        )
+        assert result == {}
+
+    def test_for_else(self, gx):
+        result = analyze(
+            gx, "def f():\n for i in r:\n  out += 'x'\n else:\n  pass\n"
+        )
+        assert result == {}
+
+    def test_generator(self, gx):
+        result = analyze(
+            gx, "def f():\n for i in r:\n  out += 'x'\n  yield 1\n", is_generator=True
+        )
+        assert result == {}
+
+    def test_global_accumulator(self, gx):
+        result = analyze(
+            gx, "def f():\n global out\n for i in r:\n  out += 'x'\n"
+        )
+        assert result == {}
+
+    def test_attribute_target(self, gx):
+        result = analyze(gx, "def f():\n for i in r:\n  self.s += 'x'\n")
+        assert result == {}
+
+    def test_non_str_accumulator(self, gx):
+        # 'n' is not declared a string, so it is not a candidate
+        result = analyze(gx, "def f():\n for i in r:\n  n += 1\n")
+        assert result == {}
+
+
+class TestNesting:
+    """Only the outermost qualifying loop is claimed"""
+
+    def test_outermost_wins(self, gx):
+        source = "def f():\n for i in r:\n  for j in s:\n   out += 'x'\n"
+        result = analyze(gx, source)
+        assert len(result) == 1
+        loop = next(iter(result))
+        assert isinstance(loop, ast.For)
+        assert loop.target.id == "i"  # the outer loop
+
+    def test_sibling_loops_both_claimed(self, gx):
+        source = (
+            "def f():\n for i in r:\n  a += 'x'\n for j in s:\n  b += 'y'\n"
+        )
+        result = analyze(gx, source)
+        assert len(result) == 2
+        assert accumulated_names(result) == {"a", "b"}
+
+    def test_inner_loop_claimed_when_outer_disqualified(self, gx):
+        # the outer loop reads 'out', the inner one only appends
+        source = "def f():\n for i in r:\n  for j in s:\n   out += 'x'\n  print(out)\n"
+        result = analyze(gx, source)
+        assert len(result) == 1
+        loop = next(iter(result))
+        assert loop.target.id == "j"  # the inner loop


### PR DESCRIPTION
`out += ..` in a loop is quadratic. Strings are immutable, so each `+=` allocates a fresh `str` and copies both operands; over n iterations that copies O(n**2) bytes. CPython does not have this problem because it resizes the left operand in place whenever it holds the only reference to it.

Shed Skin has no reference counts to consult at run time, so this asks the same question at compile time instead: if the accumulator is a local that the loop touches *only* as the target of `+=`, nothing can observe it while the loop runs, and codegen can append into one buffer and publish the result once, afterwards.

```python
def render(rows):
    out = ""
    for r in rows:
        out += "<tr>" + r + "</tr>"
    return out
```

before

```cpp
FOR_IN(r,rows,0,2,3)
    out = (out)->__iadd__(__add_strs(3, const_1, r, const_2));
END_FOR
```

after

```cpp
str *__ss_sb0 = out?(new str(out->unit)):(new str());
FOR_IN(r,rows,0,2,3)
    __ss_sb0->unit.append((__add_strs(3, const_1, r, const_2))->unit);
END_FOR
out = __ss_sb0;
```

## Results

Best of 5 runs, idle machine, against this branch's merge base.

| benchmark | before | after | speedup | CPython |
|---|---|---|---|---|
| 200k `out += "abcdefgh"` | 11,198ms | **4.6ms** | 2430x | 30.6ms |
| html table, 40k rows | 43,084ms | **16.2ms** | 2654x | 47.8ms |
| csv rows, 150k lines | 9,593ms | **21.3ms** | 450x | 75.0ms |

All three were slower than CPython before and are now 3-7x faster than it, which is the normal range for Shed Skin. For reference, hand-rewriting the first benchmark to `"".join(parts)` gives 10ms, so the rewritten loop is now faster than the workaround it removes the need for.

Nothing else moves: recursive `fib` +1.5%, list append -0.6%, dict ops +0.3%, and translating `examples/doom` is -0.5%. The analysis is one pass per function, cached.

## Why it is sound

The buffer is a *fresh* `str` seeded by copy, and the accumulator variable is not reassigned until the loop is done. Any pre-existing alias therefore keeps pointing at the original, unmodified string, exactly as Python requires:

```python
a = "start"
b = a
for i in range(3):
    a += "x"
# a == "startxxx", b == "start"
```

The rewrite is refused whenever the accumulator could be observed mid-loop. Each of these has a test, and each is refused for a reason that shows up as wrong output otherwise:

- **any read of the name inside the loop**, header included. A read would see the pre-loop value. This also covers `out += out`, a `while` test that inspects the accumulator, `for c in out:`, and reassignment inside the body.
- **the loop sitting inside a `try` in the same function.** Python leaves the accumulator holding everything appended before an exception; a builder would not have published anything yet.
- **a `for`/`else` clause**, which would run before the value is published.
- **generators**, whose locals survive across yields.
- **non-local targets**: globals, and attributes such as `self.s`, which stay on the existing path.

Loops nested inside a qualifying loop are left alone; the outermost one already covers them, and transforming both would publish once per outer iteration.

## Structure

- `shedskin/strbuild.py` (new) decides which loops qualify. No codegen, no side effects, and it is the only place the conditions are written down.
- `cpp.py` gains `sb_begin`/`sb_end` around `visit_For`/`visit_While`, and a branch in `visit_AugAssign` that routes a claimed `+=` into the buffer. `visit_For`/`visit_While` bodies moved to `impl_visit_for`/`impl_visit_while` so the wrapper stays readable.

## Testing

- `tests/unit/test_strbuild.py` (new): 21 tests over the analysis, split into loops it must claim, loops it must refuse, and nesting behaviour.
- `tests/test_opt_string_builder/` (new): 21 end-to-end cases that run under both CPython and Shed Skin and assert identical results, covering every refusal above plus aliasing, zero iterations, `break`/`continue`, nesting, `while`, formal parameters, and multiple accumulators in one loop.
- `shedskin runtests`: 220/220 (218 before, plus the two new targets).
- `tests/unit`: 267 passed.
- `mypy --strict`: clean.

Generated code was also inspected per function to confirm the rewrite fires exactly where intended and nowhere else, rather than passing by not firing at all.

## Not covered

**`bytes` deliberately, and it cannot be added as-is.** `bytes::__iadd__` branches on the runtime `frozen` flag: frozen (`bytes`) copies and is quadratic, unfrozen (`bytearray`) appends in place and is already linear. Only the first half wants this rewrite, but the two share a single `bytes_` class in the type system, so an accumulator inferred as `{(bytes_, 0)}` may be either and no compile-time predicate can separate them. Applying the rewrite to a `bytearray` would turn correct in-place mutation into a rebind its aliases cannot see -- a silent wrong answer. Making this possible means splitting `bytes` and `bytearray` into distinct classes so `frozen` becomes static, which is worth doing on its own merits but is a separate change.

Accumulators that are globals or instance attributes are also untouched, since neither is provably unaliased.
