### PR TITLE
Add make targets for the tests/ and examples/ suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 
-.PHONY: all sync build rebuild test lint format typecheck qa clean \
+.PHONY: all sync build rebuild test runtests runexamples lint format typecheck qa clean \
         distclean wheel sdist dist check publish-test publish upgrade \
         coverage coverage-html docs docs-serve docs-clean release help
+
+# Build type for the cmake-driven suites (Debug is shedskin's own default)
+BUILD_TYPE ?= Release
+
+# Extra flags forwarded to 'shedskin runtests', e.g. RUNTESTS_ARGS="-j 4 -gNinja"
+RUNTESTS_ARGS ?=
 
 # Default target
 all: build
@@ -20,6 +26,14 @@ rebuild: build
 # Run tests
 test:
 	@uv run pytest tests/unit -v
+
+# Translate, compile and run the tests/ suite via cmake + ctest
+runtests:
+	@cd tests && uv run shedskin runtests --build-type $(BUILD_TYPE) $(RUNTESTS_ARGS)
+
+# Translate, compile and run the examples/ suite via cmake + ctest
+runexamples:
+	@cd examples && uv run shedskin runtests --build-type $(BUILD_TYPE) $(RUNTESTS_ARGS)
 
 # Lint with ruff
 lint:
@@ -112,7 +126,9 @@ help:
 	@echo "  sync         - Sync environment (initial setup)"
 	@echo "  build        - Rebuild extension after code changes"
 	@echo "  rebuild      - Alias for build"
-	@echo "  test         - Run tests"
+	@echo "  test         - Run unit tests with pytest"
+	@echo "  runtests     - Build and run the tests/ suite (cmake + ctest)"
+	@echo "  runexamples  - Build and run the examples/ suite (cmake + ctest)"
 	@echo "  lint         - Lint with ruff"
 	@echo "  format       - Format with ruff"
 	@echo "  typecheck    - Type check with mypy"


### PR DESCRIPTION
Adds `make runtests` and `make runexamples`, so the two cmake-driven suites can be run the same way as everything else in the Makefile.

Both wrap the invocation CI already uses (`.github/workflows/ci.yml`):

```make
runtests:
	@cd tests && uv run shedskin runtests --build-type $(BUILD_TYPE) $(RUNTESTS_ARGS)

runexamples:
	@cd examples && uv run shedskin runtests --build-type $(BUILD_TYPE) $(RUNTESTS_ARGS)
```

The `cd` is required rather than cosmetic. `TestRunner` takes its source directory from `pathlib.Path.cwd()` and its build directory from `cwd/build` (`shedskin/cmake.py:1168`), so there is no flag that points the runner at a suite directory.

Two variables, both defaulting to what CI uses:

- `BUILD_TYPE ?= Release`. Shed Skin's own default is `Debug`, so without this the targets would be slower than CI and would not reproduce it.
- `RUNTESTS_ARGS ?=`, a passthrough for `-j 4`, `-gNinja`, `--run <test>`, `--stoponfail` and friends.

`make test` is unchanged and still means the pytest unit tests; its `help` line now says so, since three test-ish targets now sit next to each other.

## `qa` is left alone

`qa` remains `test lint typecheck format`. Adding `runtests` would take it from roughly 30 seconds to several minutes, and adding `runexamples` would make it impractical to run at all. The new targets are meant to be invoked deliberately.

## Verification

- `make test`: 256 passed.
- `make runtests RUNTESTS_ARGS="--run test_builtin_iter"`: translated, compiled, linked, and ctest reported 1/1 passed in 10s.
- `make runexamples`: cmake configured `examples/` and began building, but I did not run it to completion -- `examples/CMakeLists.txt` adds every example as a subdirectory, so the full corpus compiles regardless of any ctest-level filter, and the run is long. It exercises the same code path as `runtests`, which was verified end to end.

Tested on macOS 15 / arm64, CPython 3.13.
