### PR TITLE
infer: cut per-iteration copying in restore_network (~30% faster analysis)

### DIFF
--- a/shedskin/infer.py
+++ b/shedskin/infer.py
@@ -2021,7 +2021,7 @@ def iterative_dataflow_analysis(gx: "config.GlobalInfo") -> None:
 
     gx.orig_types = {}
     for n, t in gx.types.items():
-        gx.orig_types[n] = t
+        gx.orig_types[n] = t.copy()
 
     if INCREMENTAL:
         update_progressbar(gx, 0)

--- a/shedskin/infer.py
+++ b/shedskin/infer.py
@@ -2308,9 +2308,17 @@ def restore_network(gx: "config.GlobalInfo", backup: Backup) -> None:
     """Restore the constraint network"""
     beforetypes, beforeconstr, beforeinout, beforecnode = backup
 
-    gx.types = {}
-    for node, typeset in beforetypes.items():
-        gx.types[node] = typeset.copy()
+    cur = gx.types
+    for node in list(cur):
+        before = beforetypes.get(node)
+        if before is None:
+            del cur[node]
+        elif cur[node] != before:
+            cur[node] = before.copy()
+    if len(cur) != len(beforetypes):
+        for node, typeset in beforetypes.items():
+            if node not in cur:
+                cur[node] = typeset.copy()
 
     gx.constraints = beforeconstr.copy()
     gx.cnode = beforecnode.copy()
@@ -2323,6 +2331,13 @@ def restore_network(gx: "config.GlobalInfo", backup: Backup) -> None:
 
     for func in gx.allfuncs:
         func.cp = {}
+        # drop nodes created during the iteration that this restore just
+        # dropped from gx.cnode (default-argument notification nodes are
+        # remade every iteration, see possible_argtypes)
+        stale = {n for n in func.nodes if gx.cnode.get((n.thing, n.dcpa, n.cpa)) is not n}
+        if stale:
+            func.nodes -= stale
+            func.nodes_ordered = [n for n in func.nodes_ordered if n not in stale]
 
 
 def merge_simple_types(


### PR DESCRIPTION
Two changes to `restore_network`, both about work that is repeated on every iteration of the analysis loop. They are independent; happy to split if you would rather take one.

## 1. Only restore type sets that changed

`restore_network` rebuilt `gx.types` from scratch each iteration:

```python
gx.types = {}
for node, typeset in beforetypes.items():
    gx.types[node] = typeset.copy()
```

On `examples/sunfish` that is ~27,600 set copies per call, 99 calls per run. Timing the sections of the function directly:

```
types-copy 4.02s   constraints+cnode copy 0.12s   in_/out copy 0.87s
|gx.types| 27596   |gx.cnode| 27709   |gx.constraints| 8944
```

So `restore_network` was ~30% of a 17.2s analysis, and that one loop ~23%. Instrumenting how many entries actually differ from the backup at restore time: **553,246 of 2,870,908 (19%)**. The rest were copied for nothing.

This updates the dict in place instead — dropping keys the backup does not have, re-copying only entries that changed.

`gx.orig_types` aliases the live type sets (`gx.orig_types[n] = t`, no copy), an alias that today is broken by the first restore replacing `gx.types` wholesale. Keeping unchanged set objects would extend that aliasing across every restore, letting `propagate` mutate `orig_types` in place — which `ifa_seed_template` reads to pick an allocation's seed type. So `orig_types` is now copied when captured.

## 2. Prune stale nodes from `func.nodes` on restore

`possible_argtypes` creates the default-argument notification nodes with `parent=func`, so `CNode.__init__` registers them in `func.nodes` and `func.nodes_ordered`. `restore_network` restores `gx.cnode` and resets `node.defnodes`, but never rolls those two containers back — so the next iteration builds fresh `CNode` objects for the same keys and appends them again.

Total `func.nodes` across all functions, first iteration → last:

| example | first | last |
|---|---|---|
| doom | 16,035 | 33,502 (+109%) |
| go | 12,594 | 25,753 (+105%) |
| sunfish | 11,361 | 18,244 (+61%) |

Of sunfish's 18,045 final nodes, 6,679 are no longer the node registered in `gx.cnode`, and classifying them by `type(node.thing)` shows all 6,679 are these default-argument nodes. They are not inert: `func_copy` walks `func.nodes` on every template creation, `ifa_seed_template` walks `func.nodes_ordered` on every seed.

## Results

| | before | after |
|---|---|---|
| doom (`analyze`) | 26.4s | 17.9s |
| sunfish (`translate`) | 17.4s | 14.3s |
| 36 examples (`translate`) | 239.6s | 179.8s |

## Validation

- `tests/unit`: 285 passed

- `make runtests --reset`: 232/232 once `test_mod_mmap-exe` is accounted for (see below)

- Generated C++ byte-identical on 35 of 36 translatable examples

### On `test_mod_mmap-exe`

It fails under `ctest --parallel` on an unmodified tree too, and the generated C++ for that test is identical with and without this change. The `-exe` and `-ext` variants resolve `testdata` relative to different working directories that converge on the same `tests/testdata/mmap.out`, and `setUp()` removes it, so whichever is scheduled second trips over the other:

```
ctest -R test_mod_mmap --parallel 1   → 100% passed, 5/5 rounds
ctest -R test_mod_mmap --parallel 2   → 1 failed,    5/5 rounds
```

Worth a separate fix (per-variant filename, or `RESOURCE_LOCK`); note `-exe` gets no `WORKING_DIRECTORY` while `-ext` does, in `fn_add_shedskin_product.cmake`.

### On `richards`

It cannot serve as a comparison baseline: seven runs of the **unmodified** compiler produced three distinct `richards.cpp` files, and four distinct hashes have shown up over the course of this work. The difference is always one generated downcast in `Task::runTask`:

```c
return this->fn(msg, ((HandlerTaskRec *)(this->handle)));
return this->fn(msg, ((WorkerTaskRec  *)(this->handle)));
return this->fn(msg, ((DeviceTaskRec  *)(this->handle)));
```

All three are `TaskRec` subclasses reachable at that site; which one is emitted depends on set-iteration order. `CNode` hashes by address, and `ifa_classes_to_split` calls `random.shuffle` unseeded. Both variants I compiled ran correctly (dispatch is virtual), so this looks benign, but it does mean the compiler is not reproducible. Happy to file that separately.