### PR TITLE
tests: serialize -exe/-ext test pairs to fix test_mod_mmap race

### DIFF
--- a/shedskin/resources/cmake/fn_add_shedskin_product.cmake
+++ b/shedskin/resources/cmake/fn_add_shedskin_product.cmake
@@ -463,6 +463,10 @@ function(add_shedskin_product)
             else()
                 add_test(NAME ${EXE} COMMAND ${EXE})
             endif()
+            # the -exe and -ext variants of a test run the same code against
+            # the same files under tests/testdata, so they must not run
+            # concurrently (see test_mod_mmap)
+            set_tests_properties(${EXE} PROPERTIES RESOURCE_LOCK ${name})
         endif()
     endif()
 
@@ -630,6 +634,7 @@ function(add_shedskin_product)
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		    )
 	    endif()
+            set_tests_properties(${EXT} PROPERTIES RESOURCE_LOCK ${name})
         endif()
 
     endif()


### PR DESCRIPTION
```sh
ctest -R test_mod_mmap --parallel 1   -> passed, 5/5 rounds
ctest -R test_mod_mmap --parallel 2   -> 1 failed, 5/5 rounds
```
with the fix:
```sh
test_mod_mmap --parallel 2   -> 6/6 passed
full suite   --parallel 16   -> 232/232 (1.04s -> 1.83s)
```
