### PR TITLE
array.buffer_info

### DIFF
--- a/shedskin/cpp.py
+++ b/shedskin/cpp.py
@@ -2746,6 +2746,20 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
             return func.ident == funcname
         return False
 
+    def pointer_may_overflow_int32(self) -> bool:
+        """Whether a pointer value cast to __ss_int (as id() and
+        array.buffer_info() both do) can lose bits under --int32.
+
+        Under --int32, __ss_int is typedef'd to int32_t, a fixed-width
+        4-byte type -- unlike C's plain 'int', its size does not depend on
+        the host/target platform at all, so there is nothing to measure
+        there. The only real unknown is how wide a pointer is on the
+        platform doing the (default same-machine) build; check that
+        directly, and use '>' rather than pinning it to exactly 8 so a
+        platform with even wider pointers is still caught.
+        """
+        return self.gx.int32 and struct.calcsize("P") > 4
+
     def add_args_arg(self, node: ast.Call, funcs: list["python.Function"]) -> None:
         """append argument that describes which formals are actually filled in"""
         if self.library_func(funcs, "datetime", "time", "replace") or self.library_func(
@@ -2896,13 +2910,18 @@ class GenerateVisitor(ast_utils.BaseNodeVisitor):
                     mv=self.mv,
                 )
         if self.library_func(funcs, "builtin", None, "id"):
-            if (
-                struct.calcsize("P") == 8
-                and struct.calcsize("i") == 4
-                and self.gx.int32
-            ):
+            if self.pointer_may_overflow_int32():
                 error.error(
                     "return value of 'id' does not fit in 32-bit integer (try shedskin --int64)",
+                    self.gx,
+                    node,
+                    warning=True,
+                    mv=self.mv,
+                )
+        if self.library_func(funcs, "array", "array", "buffer_info"):
+            if self.pointer_may_overflow_int32():
+                error.error(
+                    "'buffer_info' address does not fit in 32-bit integer (try shedskin --int64)",
                     self.gx,
                     node,
                     warning=True,

--- a/shedskin/lib/array.hpp
+++ b/shedskin/lib/array.hpp
@@ -47,6 +47,7 @@ public:
 
     list<T> *tolist();
     bytes *tobytes();
+    tuple2<__ss_int, __ss_int> *buffer_info();
 
     T __getitem__(__ss_int i);
     T __getfast__(__ss_int i);
@@ -200,6 +201,19 @@ template<class T> bytes *array<T>::tobytes() {
 template<class T> void *array<T>::fromstring(bytes *s) {
     frombytes(s);
     return NULL;
+}
+
+/* Address of the backing buffer plus its length in *elements* (not bytes --
+ * multiply by itemsize for the byte size, same convention as CPython). Kept
+ * as a plain (__ss_int, __ss_int) tuple for consistency with the rest of
+ * this module's API (e.g. tolist()/tobytes()) rather than widening the
+ * address field, so under --int32 the address silently truncates exactly
+ * like id() does; see the matching warning emitted in cpp.py. */
+template<class T> tuple2<__ss_int, __ss_int> *array<T>::buffer_info() {
+    void *addr = this->units.empty() ? NULL : (void *)&(this->units[0]);
+    __ss_int address = (__ss_int)(intptr_t)addr;
+    __ss_int length = (__ss_int)(this->units.size() / itemsize);
+    return new tuple2<__ss_int, __ss_int>(2, address, length);
 }
 
 template<class T> void *array<T>::frombytes(bytes *s) {

--- a/shedskin/lib/array.py
+++ b/shedskin/lib/array.py
@@ -21,6 +21,8 @@ class array:
         return [self.unit]
     def tobytes(self):
         return b''
+    def buffer_info(self):
+        return (0, 0)
 
     def fromlist(self, l):
         pass

--- a/tests/test_mod_array/test_mod_array.py
+++ b/tests/test_mod_array/test_mod_array.py
@@ -10,6 +10,17 @@ def test_typecodes():
     assert arr.itemsize == 4
 
 
+def test_buffer_info():
+    arr = array.array('i', range(10))
+    address, length = arr.buffer_info()
+    assert length == 10
+    assert address != 0
+
+    empty = array.array('i')
+    _, length = empty.buffer_info()
+    assert length == 0
+
+
 def test_file():
     testdir = os.curdir
     while not os.path.exists(os.path.join(testdir, "testdata")) and os.path.exists(os.pardir):
@@ -434,6 +445,7 @@ def test_extend_overflow_no_corruption():
 
 def test_all():
     test_typecodes()
+    test_buffer_info()
     test_list()
     test_bytes()
     test_fromstring()


### PR DESCRIPTION
same int32 warning as for id()
