### PR TITLE
copy.Error

### DIFF
--- a/shedskin/lib/copy.cpp
+++ b/shedskin/lib/copy.cpp
@@ -4,8 +4,10 @@
 
 namespace __copy__ {
 
-void __init() {
+class_ *cl_Error;
 
+void __init() {
+    cl_Error = new class_("Error");
 }
 
 

--- a/shedskin/lib/copy.hpp
+++ b/shedskin/lib/copy.hpp
@@ -8,6 +8,17 @@
 using namespace __shedskin__;
 namespace __copy__ {
 
+extern class_ *cl_Error;
+
+class Error : public Exception {
+public:
+
+    Error() {}
+    Error(str *msg) : Exception(msg) {
+        this->__class__ = cl_Error;
+    }
+};
+
 template<class T> T deepcopy(T t) {
     return __deepcopy(t);
 }

--- a/shedskin/lib/copy.py
+++ b/shedskin/lib/copy.py
@@ -1,6 +1,10 @@
 # Copyright 2005-2011 Mark Dufour and contributors; License Expat (See LICENSE)
 
 
+class Error(Exception):
+    pass
+
+
 def copy(a):
     a.__copy__() # XXX hardcode in ss.py?
     return a

--- a/tests/test_mod_copy/test_mod_copy.py
+++ b/tests/test_mod_copy/test_mod_copy.py
@@ -131,6 +131,26 @@ def test_copy_deque():
 
 
 
+def test_error():
+    # copy.Error is effectively unreachable in CPython 3 (object always
+    # provides __reduce_ex__), and shedskin never raises it either, since
+    # copyability is decided at compile time. It exists so that code
+    # raising/catching it compiles.
+    error = ''
+    try:
+        raise copy.Error('un(shallow)copyable object')
+    except copy.Error as e:
+        error = str(e)
+    assert error == 'un(shallow)copyable object'
+
+    caught = False
+    try:
+        raise copy.Error('oops')
+    except Exception:
+        caught = True
+    assert caught
+
+
 def test_all():
     test_copy1()
     test_copy2()
@@ -140,6 +160,7 @@ def test_all():
     test_copy_obj1()
     test_copy_obj2()
     test_copy_obj3()
+    test_error()
 
 if __name__ == '__main__':
     test_all()


### PR DESCRIPTION
not super useful, but for 'completeness'
